### PR TITLE
feat!: Add dependencies to deployments 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 1.0.3
 
--Consolidate core testnet deployments in the v2.0.1 assets files. This is a workaround until a better querying mechanism is implemented which allows easy querying of the latest addresses for all networks.
+- Consolidate core testnet deployments in the v2.0.1 assets files. This is a workaround until a better querying mechanism is implemented which allows easy querying of the latest addresses for all networks.
 
 # 1.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next version
 
+- Add dependencies to deployments. This allows querying for e.g. periphery or strat contracts that are tied to a specific Mangrove instance.
+
 # 1.0.3
 
 - Consolidate core testnet deployments in the v2.0.1 assets files. This is a workaround until a better querying mechanism is implemented which allows easy querying of the latest addresses for all networks.

--- a/README.md
+++ b/README.md
@@ -25,25 +25,42 @@ type DeploymentFilter {
   version?: string;
   released?: boolean;      // Defaults to true.
   network?: string;        // Chain ID of the network
-  deploymentName?: string; // An optional deployment name which may be used to differentiate between multiple deployments of the same contract version.
-                           // Used for test token deployments to distinguish between tokens based on the same contract.
+  deploymentName?: string; // An optional deployment name which may be used to differentiate
+                           // between multiple deployments of the same contract version.
+                           // Used eg for test token deployments to distinguish between tokens
+                           // based on the same contract.
+  dependencies?: {name: string, address: string};
+                           // An optional list of dependencies in the form of a deployment or
+                           // contract name and an address.
+                           // Can eg be used to get deployments tied to a specific Mangrove instance.
 }
 ```
 
 The method will return a `VersionDeployments` object or `undefined` if no deployment was found for the specified filter.
 
 ```ts
+type Dependency = {
+  name: string;
+  address: string;
+};
+
+type AddressAndDependencies = {
+  address: string;
+  dependencies?: Dependency[];
+};
+
 type VersionDeployments {
   contractName: string;
   deploymentName?: string;
   version: string;
-  released: boolean;          // The deployment is of a released contract version;
+  released: boolean;           // The deployment is of a released contract version;
   abi: any[];
-  networkAddresses: Record<   // Addresses of the contract by network
+  networkAddresses: Record<    // Addresses of the contract by network
     string,
     {
-      primaryAddress: string; // The primary deployment on the network which should normally be used
-      allAddresses: string[]; // All deployments on the network of this contract version.
+      primaryAddress?: string; // An optional primary deployment on the network which should normally be used
+      allAddresses: AddressAndDependencies[];
+                               // All deployments on the network of this contract version.
     }
   >;
 }
@@ -67,21 +84,36 @@ const mangroveGörli = getMangroveVersionDeployments({ network: "5" });
 const mangrove200 = getMangroveVersionDeployments({ version: "2.0.0" });
 
 // Similar methods exist for the MgvReader and MgvOracle contracts
-const mgvReader = getMgvReaderVersionDeployments();
-const mgvOracle = getMgvOracleVersionDeployments();
+// For these, one will often want to match a specific Mangrove instance
+const mgvReader = getMgvReaderVersionDeployments({
+  dependencies: [{ name: "Mangrove", address: "0x..." }],
+});
+const mgvOracle = getMgvOracleVersionDeployments({
+  dependencies: [{ name: "Mangrove", address: "0x..." }],
+});
 ```
 
 - Strats
 
 ```ts
 // MangroveOrder contract
-const mangroveOrder = getMangroveOrderVersionDeployments();
-const mangroveOrderRouter = getMangroveOrderRouterVersionDeployments();
+const mangroveOrder = getMangroveOrderVersionDeployments({
+  dependencies: [{ name: "Mangrove", address: "0x..." }],
+});
+const mangroveOrderRouter = getMangroveOrderRouterVersionDeployments({
+  dependencies: [{ name: "Mangrove", address: "0x..." }],
+});
 
 // Kandel
-const kandelSeeder = getKandelSeederVersionDeployments();
-const aaveKandelSeeder = getAaveKandelSeederVersionDeployments();
-const aavePooledRouter = getAavePooledRouterVersionDeployments();
+const kandelSeeder = getKandelSeederVersionDeployments({
+  dependencies: [{ name: "Mangrove", address: "0x..." }],
+});
+const aaveKandelSeeder = getAaveKandelSeederVersionDeployments({
+  dependencies: [{ name: "Mangrove", address: "0x..." }],
+});
+const aavePooledRouter = getAavePooledRouterVersionDeployments({
+  dependencies: [{ name: "Mangrove", address: "0x..." }],
+});
 ```
 
 - Test ERC20 tokens

--- a/src/assets/core/v2.0.1/Mangrove.json
+++ b/src/assets/core/v2.0.1/Mangrove.json
@@ -5,11 +5,19 @@
   "networkAddresses": {
     "80001": {
       "primaryAddress": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39",
-      "allAddresses": ["0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"]
+      "allAddresses": [
+        {
+          "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+        }
+      ]
     },
     "11155111": {
       "primaryAddress": "0x5B2F8058Df0A0b7744FDb4fD0885FbCD2394194C",
-      "allAddresses": ["0x5B2F8058Df0A0b7744FDb4fD0885FbCD2394194C"]
+      "allAddresses": [
+        {
+          "address": "0x5B2F8058Df0A0b7744FDb4fD0885FbCD2394194C"
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/core/v2.0.1/MgvOracle.json
+++ b/src/assets/core/v2.0.1/MgvOracle.json
@@ -5,11 +5,31 @@
   "networkAddresses": {
     "80001": {
       "primaryAddress": "0xC0fB136768e4b7725d674B8Bcd366A5dc2b5F976",
-      "allAddresses": ["0xC0fB136768e4b7725d674B8Bcd366A5dc2b5F976"]
+      "allAddresses": [
+        {
+          "address": "0xC0fB136768e4b7725d674B8Bcd366A5dc2b5F976",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+            }
+          ]
+        }
+      ]
     },
     "11155111": {
       "primaryAddress": "0xF15A2ada64A9C3C14ca11359c8F1d22B063DB2AD",
-      "allAddresses": ["0xF15A2ada64A9C3C14ca11359c8F1d22B063DB2AD"]
+      "allAddresses": [
+        {
+          "address": "0xF15A2ada64A9C3C14ca11359c8F1d22B063DB2AD",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x5B2F8058Df0A0b7744FDb4fD0885FbCD2394194C"
+            }
+          ]
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/core/v2.0.1/MgvReader.json
+++ b/src/assets/core/v2.0.1/MgvReader.json
@@ -5,11 +5,31 @@
   "networkAddresses": {
     "80001": {
       "primaryAddress": "0x26d24Dd4aFcB9D1cD30baf804Fa22aFa643327CD",
-      "allAddresses": ["0x26d24Dd4aFcB9D1cD30baf804Fa22aFa643327CD"]
+      "allAddresses": [
+        {
+          "address": "0x26d24Dd4aFcB9D1cD30baf804Fa22aFa643327CD",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+            }
+          ]
+        }
+      ]
     },
     "11155111": {
       "primaryAddress": "0xE9F139F4D31477E71e746a6744e5314F9d6DB382",
-      "allAddresses": ["0xE9F139F4D31477E71e746a6744e5314F9d6DB382"]
+      "allAddresses": [
+        {
+          "address": "0xE9F139F4D31477E71e746a6744e5314F9d6DB382",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x5B2F8058Df0A0b7744FDb4fD0885FbCD2394194C"
+            }
+          ]
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/strats/v1.0.0/AaveKandelSeeder.json
+++ b/src/assets/strats/v1.0.0/AaveKandelSeeder.json
@@ -4,8 +4,17 @@
   "version": "1.0.0",
   "networkAddresses": {
     "80001": {
-      "primaryAddress": "0xC56CEc2A5912B49AAacEc0F391471Aeb4eb8D9D2",
-      "allAddresses": ["0xC56CEc2A5912B49AAacEc0F391471Aeb4eb8D9D2"]
+      "allAddresses": [
+        {
+          "address": "0xC56CEc2A5912B49AAacEc0F391471Aeb4eb8D9D2",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+            }
+          ]
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/strats/v1.0.0/AavePooledRouter.json
+++ b/src/assets/strats/v1.0.0/AavePooledRouter.json
@@ -4,8 +4,17 @@
   "version": "1.0.0",
   "networkAddresses": {
     "80001": {
-      "primaryAddress": "0xF147995331B1511D5fA7c196fA3466d647142C5e",
-      "allAddresses": ["0xF147995331B1511D5fA7c196fA3466d647142C5e"]
+      "allAddresses": [
+        {
+          "address": "0xF147995331B1511D5fA7c196fA3466d647142C5e",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+            }
+          ]
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/strats/v1.0.0/KandelLib.json
+++ b/src/assets/strats/v1.0.0/KandelLib.json
@@ -5,8 +5,17 @@
   "version": "1.0.0",
   "networkAddresses": {
     "80001": {
-      "primaryAddress": "0x6733a81A505a15eBd2CAB15eE2F978FF74A18dD4",
-      "allAddresses": ["0x6733a81A505a15eBd2CAB15eE2F978FF74A18dD4"]
+      "allAddresses": [
+        {
+          "address": "0x6733a81A505a15eBd2CAB15eE2F978FF74A18dD4",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+            }
+          ]
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/strats/v1.0.0/KandelSeeder.json
+++ b/src/assets/strats/v1.0.0/KandelSeeder.json
@@ -4,8 +4,17 @@
   "version": "1.0.0",
   "networkAddresses": {
     "80001": {
-      "primaryAddress": "0x68A1778E4D08D8f6De35323a9040791CE8E9EF4C",
-      "allAddresses": ["0x68A1778E4D08D8f6De35323a9040791CE8E9EF4C"]
+      "allAddresses": [
+        {
+          "address": "0x68A1778E4D08D8f6De35323a9040791CE8E9EF4C",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+            }
+          ]
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/strats/v1.0.0/MangroveOrder-Router.json
+++ b/src/assets/strats/v1.0.0/MangroveOrder-Router.json
@@ -5,8 +5,17 @@
   "version": "1.0.0",
   "networkAddresses": {
     "80001": {
-      "primaryAddress": "0x983d34A6163F00D5DfDCC3f21ff70cECa2a8643D",
-      "allAddresses": ["0x983d34A6163F00D5DfDCC3f21ff70cECa2a8643D"]
+      "allAddresses": [
+        {
+          "address": "0x983d34A6163F00D5DfDCC3f21ff70cECa2a8643D",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+            }
+          ]
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/strats/v1.0.0/MangroveOrder.json
+++ b/src/assets/strats/v1.0.0/MangroveOrder.json
@@ -4,8 +4,17 @@
   "version": "1.0.0",
   "networkAddresses": {
     "80001": {
-      "primaryAddress": "0x6469064C68B1Bd06861dabD20dF835Fa71Dff695",
-      "allAddresses": ["0x6469064C68B1Bd06861dabD20dF835Fa71Dff695"]
+      "allAddresses": [
+        {
+          "address": "0x6469064C68B1Bd06861dabD20dF835Fa71Dff695",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+            }
+          ]
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/testErc20s/v1.3.0/PxMATIC.json
+++ b/src/assets/testErc20s/v1.3.0/PxMATIC.json
@@ -5,8 +5,12 @@
   "version": "1.3.0",
   "networkAddresses": {
     "137": {
-      "primaryAddress": "0xba6fBacEeeE55D2d657Eb26023C64002e23Af5E8",
-      "allAddresses": ["0xba6fBacEeeE55D2d657Eb26023C64002e23Af5E8"]
+      "allAddresses": [
+        {
+          "address": "0xba6fBacEeeE55D2d657Eb26023C64002e23Af5E8",
+          "dependencies": []
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/testErc20s/v1.3.0/PxUSDC.json
+++ b/src/assets/testErc20s/v1.3.0/PxUSDC.json
@@ -5,8 +5,12 @@
   "version": "1.3.0",
   "networkAddresses": {
     "137": {
-      "primaryAddress": "0xB70041dC246412E0DCE34bd788062E969276E737",
-      "allAddresses": ["0xB70041dC246412E0DCE34bd788062E969276E737"]
+      "allAddresses": [
+        {
+          "address": "0xB70041dC246412E0DCE34bd788062E969276E737",
+          "dependencies": []
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/testErc20s/v1.5.3/USDT.json
+++ b/src/assets/testErc20s/v1.5.3/USDT.json
@@ -5,8 +5,12 @@
   "version": "1.5.3",
   "networkAddresses": {
     "80001": {
-      "primaryAddress": "0xe8099699aa4A79d89dBD20A63C50b7d35ED3CD9e",
-      "allAddresses": ["0xe8099699aa4A79d89dBD20A63C50b7d35ED3CD9e"]
+      "allAddresses": [
+        {
+          "address": "0xe8099699aa4A79d89dBD20A63C50b7d35ED3CD9e",
+          "dependencies": []
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/testErc20s/v1.5.3/WBTC.json
+++ b/src/assets/testErc20s/v1.5.3/WBTC.json
@@ -5,8 +5,12 @@
   "version": "1.5.3",
   "networkAddresses": {
     "80001": {
-      "primaryAddress": "0xf402f6197d979F0A4cba61596921a3d762520570",
-      "allAddresses": ["0xf402f6197d979F0A4cba61596921a3d762520570"]
+      "allAddresses": [
+        {
+          "address": "0xf402f6197d979F0A4cba61596921a3d762520570",
+          "dependencies": []
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/testErc20s/v1.5.3/WMATIC.json
+++ b/src/assets/testErc20s/v1.5.3/WMATIC.json
@@ -5,8 +5,12 @@
   "version": "1.5.3",
   "networkAddresses": {
     "80001": {
-      "primaryAddress": "0x193163EeFfc795F9d573b171aB12cCDdE10392e8",
-      "allAddresses": ["0x193163EeFfc795F9d573b171aB12cCDdE10392e8"]
+      "allAddresses": [
+        {
+          "address": "0x193163EeFfc795F9d573b171aB12cCDdE10392e8",
+          "dependencies": []
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/testErc20s/v1.5.6/DAI.json
+++ b/src/assets/testErc20s/v1.5.6/DAI.json
@@ -5,8 +5,12 @@
   "version": "1.5.6",
   "networkAddresses": {
     "80001": {
-      "primaryAddress": "0x5b67e3fa6f8AF1ca80C78102B8c039a40B96689E",
-      "allAddresses": ["0x5b67e3fa6f8AF1ca80C78102B8c039a40B96689E"]
+      "allAddresses": [
+        {
+          "address": "0x5b67e3fa6f8AF1ca80C78102B8c039a40B96689E",
+          "dependencies": []
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/testErc20s/v1.5.6/USDC.json
+++ b/src/assets/testErc20s/v1.5.6/USDC.json
@@ -5,8 +5,12 @@
   "version": "1.5.6",
   "networkAddresses": {
     "80001": {
-      "primaryAddress": "0xe9259C5B6936Ee6439654171AFd674b31a533985",
-      "allAddresses": ["0xe9259C5B6936Ee6439654171AFd674b31a533985"]
+      "allAddresses": [
+        {
+          "address": "0xe9259C5B6936Ee6439654171AFd674b31a533985",
+          "dependencies": []
+        }
+      ]
     }
   },
   "abi": [

--- a/src/assets/testErc20s/v1.5.6/WETH.json
+++ b/src/assets/testErc20s/v1.5.6/WETH.json
@@ -5,8 +5,12 @@
   "version": "1.5.6",
   "networkAddresses": {
     "80001": {
-      "primaryAddress": "0x406bF0fcE108dD8864627EC6816AaFF8336f8231",
-      "allAddresses": ["0x406bF0fcE108dD8864627EC6816AaFF8336f8231"]
+      "allAddresses": [
+        {
+          "address": "0x406bF0fcE108dD8864627EC6816AaFF8336f8231",
+          "dependencies": []
+        }
+      ]
     }
   },
   "abi": [

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,17 @@
+/**
+ * Contract deployments are normally tied to other deployments, such as the Mangrove contract.
+ * This is captured by a dependency, which consists of a deployment or contract name and an address.
+ */
+export type Dependency = {
+  name: string;
+  address: string;
+};
+
+export type AddressAndDependencies = {
+  address: string;
+  dependencies?: Dependency[];
+};
+
 export type VersionDeployments = {
   contractName: string;
   deploymentName?: string;
@@ -7,8 +21,8 @@ export type VersionDeployments = {
   networkAddresses: Record<
     string,
     {
-      primaryAddress: string;
-      allAddresses: string[];
+      primaryAddress?: string;
+      allAddresses: AddressAndDependencies[];
     }
   >;
 };
@@ -18,4 +32,5 @@ export type DeploymentFilter = {
   released?: boolean;
   network?: string;
   deploymentName?: string;
+  dependencies?: Dependency[];
 };

--- a/test/unit/utils.unit.test.ts
+++ b/test/unit/utils.unit.test.ts
@@ -14,7 +14,10 @@ describe("utils.ts", () => {
         released: false,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment: VersionDeployments = {
@@ -24,7 +27,10 @@ describe("utils.ts", () => {
         released: true, // Default filter value
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
 
@@ -52,7 +58,10 @@ describe("utils.ts", () => {
         released: true, // Default filter value
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment2: VersionDeployments = {
@@ -62,7 +71,10 @@ describe("utils.ts", () => {
         released: true, // Default filter value
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
 
@@ -89,7 +101,10 @@ describe("utils.ts", () => {
         released: false,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testUnreleasedDeployment2: VersionDeployments = {
@@ -99,7 +114,10 @@ describe("utils.ts", () => {
         released: false,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment1: VersionDeployments = {
@@ -109,7 +127,10 @@ describe("utils.ts", () => {
         released: true, // Default filter value
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment2: VersionDeployments = {
@@ -119,7 +140,10 @@ describe("utils.ts", () => {
         released: true, // Default filter value
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
 
@@ -155,7 +179,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment2: VersionDeployments = {
@@ -165,7 +192,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "73799": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "73799": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment3: VersionDeployments = {
@@ -175,7 +205,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "11297108109": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "11297108109": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment4: VersionDeployments = {
@@ -185,7 +218,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
 
@@ -213,6 +249,87 @@ describe("utils.ts", () => {
         .undefined;
     });
 
+    it("should return the correct deployment (filtered by dependencies)", () => {
+      const testReleasedDeployment1: VersionDeployments = {
+        contractName: "",
+        deploymentName: "1",
+        version: "1.2.3",
+        released: true, // Default filter value
+        abi: [],
+        networkAddresses: {
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [
+              {
+                address: "0xbeef",
+                dependencies: [
+                  { name: "dep1", address: "0xcode" },
+                  { name: "dep2", address: "0xbaaf" },
+                ],
+              },
+            ],
+          },
+        },
+      };
+      const testReleasedDeployment2: VersionDeployments = {
+        contractName: "",
+        deploymentName: "2",
+        version: "2.0.0",
+        released: true, // Default filter value
+        abi: [],
+        networkAddresses: {
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [
+              {
+                address: "0xbeef",
+                dependencies: [{ name: "dep1", address: "0xcode" }],
+              },
+            ],
+          },
+        },
+      };
+
+      const testDeployments = [
+        testReleasedDeployment2,
+        testReleasedDeployment1,
+      ];
+
+      // No dependencies required
+      expect(findDeployment({ dependencies: [] }, testDeployments)).to.equal(
+        testReleasedDeployment2,
+      );
+
+      // Chronological deployments
+      expect(
+        findDeployment(
+          { dependencies: [{ name: "dep1", address: "0xcode" }] },
+          testDeployments,
+        ),
+      ).to.equal(testReleasedDeployment2);
+
+      // Multiple dependencies
+      expect(
+        findDeployment(
+          {
+            dependencies: [
+              { name: "dep1", address: "0xcode" },
+              { name: "dep2", address: "0xbaaf" },
+            ],
+          },
+          testDeployments,
+        ),
+      ).to.equal(testReleasedDeployment1);
+
+      // Incorrect filter:
+      expect(
+        findDeployment(
+          { dependencies: [{ name: "nonDep", address: "0xcode" }] },
+          testDeployments,
+        ),
+      ).to.be.undefined;
+    });
+
     it("should return the correct deployment (filtered by version and released)", () => {
       const testReleasedDeployment1: VersionDeployments = {
         contractName: "1",
@@ -221,7 +338,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment2: VersionDeployments = {
@@ -231,7 +351,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment3: VersionDeployments = {
@@ -241,7 +364,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment4: VersionDeployments = {
@@ -251,7 +377,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
 
@@ -289,7 +418,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment2: VersionDeployments = {
@@ -299,7 +431,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment3: VersionDeployments = {
@@ -309,7 +444,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment4: VersionDeployments = {
@@ -319,7 +457,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
 
@@ -357,7 +498,10 @@ describe("utils.ts", () => {
         released: false,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testUnreleasedDeployment2: VersionDeployments = {
@@ -367,7 +511,10 @@ describe("utils.ts", () => {
         released: false,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment1: VersionDeployments = {
@@ -377,7 +524,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment2: VersionDeployments = {
@@ -387,7 +537,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "246": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "246": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment3: VersionDeployments = {
@@ -397,7 +550,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "11297108109": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "11297108109": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
       const testReleasedDeployment4: VersionDeployments = {
@@ -407,7 +563,10 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef" }],
+          },
         },
       };
 
@@ -453,7 +612,7 @@ describe("utils.ts", () => {
       ).to.equal(testUnreleasedDeployment2);
     });
 
-    it("should return the correct deployment (filtered by version, released and network)", () => {
+    it("should return the correct deployment (filtered by version, released, network, and dependencies)", () => {
       const testReleasedDeployment1: VersionDeployments = {
         contractName: "",
         deploymentName: "3",
@@ -461,7 +620,15 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "1": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [
+              {
+                address: "0xbeef",
+                dependencies: [{ name: "dep", address: "0xcode1" }],
+              },
+            ],
+          },
         },
       };
       const testReleasedDeployment2: VersionDeployments = {
@@ -471,7 +638,15 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "246": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "246": {
+            primaryAddress: "0xbeef",
+            allAddresses: [
+              {
+                address: "0xbeef",
+                dependencies: [{ name: "dep", address: "0xcode2" }],
+              },
+            ],
+          },
         },
       };
       const testReleasedDeployment3: VersionDeployments = {
@@ -481,7 +656,15 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "73799": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "73799": {
+            primaryAddress: "0xbeef",
+            allAddresses: [
+              {
+                address: "0xbeef",
+                dependencies: [{ name: "dep", address: "0xcode3" }],
+              },
+            ],
+          },
         },
       };
       const testReleasedDeployment4: VersionDeployments = {
@@ -491,7 +674,15 @@ describe("utils.ts", () => {
         released: true,
         abi: [],
         networkAddresses: {
-          "11297108109": { primaryAddress: "0xbeef", allAddresses: ["0xbeef"] },
+          "11297108109": {
+            primaryAddress: "0xbeef",
+            allAddresses: [
+              {
+                address: "0xbeef",
+                dependencies: [{ name: "dep", address: "0xcode4" }],
+              },
+            ],
+          },
         },
       };
 
@@ -506,44 +697,91 @@ describe("utils.ts", () => {
       // Reverse chronological deployments
       expect(
         findDeployment(
-          { version: "1.0.0", released: true, network: "1" },
+          {
+            version: "1.0.0",
+            released: true,
+            network: "1",
+            dependencies: [{ name: "dep", address: "0xcode1" }],
+          },
           testDeploymentsReverse,
         ),
       ).to.equal(testReleasedDeployment1);
       expect(
         findDeployment(
-          { version: "1.1.1", released: true, network: "246" },
+          {
+            version: "1.1.1",
+            released: true,
+            network: "246",
+            dependencies: [{ name: "dep", address: "0xcode2" }],
+          },
           testDeploymentsReverse,
         ),
       ).to.equal(testReleasedDeployment2);
       expect(
         findDeployment(
-          { version: "1.2.0", released: true, network: "73799" },
+          {
+            version: "1.2.0",
+            released: true,
+            network: "73799",
+            dependencies: [{ name: "dep", address: "0xcode3" }],
+          },
           testDeploymentsReverse,
         ),
       ).to.equal(testReleasedDeployment3);
       expect(
         findDeployment(
-          { version: "1.3.0", released: true, network: "11297108109" },
+          {
+            version: "1.3.0",
+            released: true,
+            network: "11297108109",
+            dependencies: [{ name: "dep", address: "0xcode4" }],
+          },
           testDeploymentsReverse,
         ),
       ).to.equal(testReleasedDeployment4);
+
       // Incorrect filter:
       expect(
         findDeployment(
-          { version: "1.3.0", released: false, network: "11297108109" },
+          {
+            version: "1.3.0",
+            released: false,
+            network: "11297108109",
+            dependencies: [{ name: "dep", address: "0xcode4" }],
+          },
           testDeploymentsReverse,
         ),
       ).to.be.undefined;
       expect(
         findDeployment(
-          { version: "1.3.0", released: true, network: "0" },
+          {
+            version: "1.3.0",
+            released: true,
+            network: "0",
+            dependencies: [{ name: "dep", address: "0xcode4" }],
+          },
           testDeploymentsReverse,
         ),
       ).to.be.undefined;
       expect(
         findDeployment(
-          { version: "2.0.0", released: true, network: "11297108109" },
+          {
+            version: "2.0.0",
+            released: true,
+            network: "11297108109",
+            dependencies: [{ name: "dep", address: "0xcode4" }],
+          },
+          testDeploymentsReverse,
+        ),
+      ).to.be.undefined;
+      expect(
+        findDeployment(
+          {
+            version: "1.3.0",
+            released: true,
+            network: "11297108109",
+            dependencies: [{ name: "dep", address: "0xcode1" }],
+          },
           testDeploymentsReverse,
         ),
       ).to.be.undefined;


### PR DESCRIPTION
This allows querying for e.g. periphery or strat contracts that are tied to a specific Mangrove instance.