### PR TITLE
feat: Add functions to get all or latest deployments for each network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Add functions to get all or latest deployments matching a filter.
 - Add function 'getLatestCoreContractsPerNetwork' to get the latest Mangrove deployments for each network along with the corresponding MgvOracle and MgvReader deployments.
-- Add function 'getLatestStratContractsPerNetwork' to get the latest latest strat contract deployments for the latest Mangrove deployment for each network..
+- Add function 'getLatestStratContractsPerNetwork' to get the latest latest strat contract deployments for the latest Mangrove deployment for each network.
 - Add dependencies to deployments. This allows querying for e.g. periphery or strat contracts that are tied to a specific Mangrove instance.
 
 # 1.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Next version
 
+- Add functions to get all or latest deployments matching a filter.
+- Add function 'getLatestCoreContractsPerNetwork' to get the latest Mangrove deployments for each network along with the corresponding MgvOracle and MgvReader deployments.
+- Add function 'getLatestStratContractsPerNetwork' to get the latest latest strat contract deployments for the latest Mangrove deployment for each network..
 - Add dependencies to deployments. This allows querying for e.g. periphery or strat contracts that are tied to a specific Mangrove instance.
 
 # 1.0.3

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,10 +1,22 @@
 import Mangrove_v2_0_1 from "./assets/core/v2.0.1/Mangrove.json";
 import MgvOracle_v2_0_1 from "./assets/core/v2.0.1/MgvOracle.json";
 import MgvReader_v2_0_1 from "./assets/core/v2.0.1/MgvReader.json";
-import { DeploymentFilter, VersionDeployments } from "./types";
-import { findDeployment } from "./utils";
+import {
+  CoreContractsNetworkDeployment,
+  DeploymentFilter,
+  VersionDeployments,
+  VersionNetworkDeployment,
+} from "./types";
+import {
+  findAllDeploymentsPerNetwork,
+  findLatestDeploymentPerNetwork,
+  findDeployment,
+} from "./utils";
 
-// This is a sorted array (newest to oldest), exported for tests
+//////////////////////////
+// Mangrove
+
+/** This is a sorted array (newest to oldest), exported for tests */
 export const _mangroveDeployments: VersionDeployments[] = [Mangrove_v2_0_1];
 
 export const getMangroveVersionDeployments = (
@@ -13,7 +25,24 @@ export const getMangroveVersionDeployments = (
   return findDeployment(filter, _mangroveDeployments);
 };
 
-// This is a sorted array (newest to oldest), exported for tests
+/** Returns all Mangrove deployments matching the filter, grouped by network. */
+export const getAllMangroveVersionDeploymentsPerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionDeployments[]> => {
+  return findAllDeploymentsPerNetwork(filter, _mangroveDeployments);
+};
+
+/** Returns the latest Mangrove deployment matching the filter for each network. */
+export const getLatestMangrovePerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionNetworkDeployment> => {
+  return findLatestDeploymentPerNetwork(filter, _mangroveDeployments);
+};
+
+//////////////////////////
+// MgvOracle
+
+/** This is a sorted array (newest to oldest), exported for tests */
 export const _mgvOracleDeployments: VersionDeployments[] = [MgvOracle_v2_0_1];
 
 export const getMgvOracleVersionDeployments = (
@@ -22,7 +51,24 @@ export const getMgvOracleVersionDeployments = (
   return findDeployment(filter, _mgvOracleDeployments);
 };
 
-// This is a sorted array (newest to oldest), exported for tests
+/** Returns all MgvOracle deployments matching the filter, grouped by network. */
+export const getAllMgvOracleVersionDeploymentsPerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionDeployments[]> => {
+  return findAllDeploymentsPerNetwork(filter, _mgvOracleDeployments);
+};
+
+/** Returns the latest MgvOracle deployment matching the filter for each network. */
+export const getLatestMgvOraclePerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionNetworkDeployment> => {
+  return findLatestDeploymentPerNetwork(filter, _mgvOracleDeployments);
+};
+
+//////////////////////////
+// MgvReader
+
+/** This is a sorted array (newest to oldest), exported for tests */
 export const _mgvReaderDeployments: VersionDeployments[] = [MgvReader_v2_0_1];
 
 export const getMgvReaderVersionDeployments = (
@@ -31,13 +77,51 @@ export const getMgvReaderVersionDeployments = (
   return findDeployment(filter, _mgvReaderDeployments);
 };
 
-// This is a temporary utility function to get deployments for all the contracts in one go
-export const getCoreContractsVersionDeployments = (
+/** Returns all MgvReader deployments matching the filter, grouped by network. */
+export const getAllMgvReaderVersionDeploymentsPerNetwork = (
   filter?: DeploymentFilter,
-): VersionDeployments[] => {
-  return [
-    getMangroveVersionDeployments(filter),
-    getMgvOracleVersionDeployments(filter),
-    getMgvReaderVersionDeployments(filter),
-  ].filter((x): x is VersionDeployments => x !== undefined);
+): Record<string, VersionDeployments[]> => {
+  return findAllDeploymentsPerNetwork(filter, _mgvReaderDeployments);
+};
+
+/** Returns the latest MgvReader deployment matching the filter for each network. */
+export const getLatestMgvReaderPerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionNetworkDeployment> => {
+  return findLatestDeploymentPerNetwork(filter, _mgvReaderDeployments);
+};
+
+//////////////////////////
+// Cross-cutting
+
+/** Get the latest Mangrove deployments for each network along with the corresponding MgvOracle and MgvReader deployments.
+ */
+export const getLatestCoreContractsPerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, CoreContractsNetworkDeployment> => {
+  const latestMangrovePerNetwork = getLatestMangrovePerNetwork(filter);
+  const latestCoreContractsPerNetwork: Record<
+    string,
+    CoreContractsNetworkDeployment
+  > = {};
+  const filterDependenciesWithoutMangrove =
+    filter?.dependencies?.filter((d) => d.name !== "Mangrove") ?? [];
+  for (const [network, mangroveDeployment] of Object.entries(
+    latestMangrovePerNetwork,
+  )) {
+    const peripheryFilter = {
+      ...filter,
+      network,
+      dependencies: [
+        ...filterDependenciesWithoutMangrove,
+        { name: "Mangrove", address: mangroveDeployment.address },
+      ],
+    };
+    latestCoreContractsPerNetwork[network] = {
+      mangrove: mangroveDeployment,
+      mgvOracle: getLatestMgvOraclePerNetwork(peripheryFilter)[network],
+      mgvReader: getLatestMgvReaderPerNetwork(peripheryFilter)[network],
+    };
+  }
+  return latestCoreContractsPerNetwork;
 };

--- a/src/strats.ts
+++ b/src/strats.ts
@@ -4,11 +4,24 @@ import KandelLib_v1_0_0 from "./assets/strats/v1.0.0/KandelLib.json";
 import KandelSeeder_v1_0_0 from "./assets/strats/v1.0.0/KandelSeeder.json";
 import MangroveOrderRouter_v1_0_0 from "./assets/strats/v1.0.0/MangroveOrder-Router.json";
 import MangroveOrder_v1_0_0 from "./assets/strats/v1.0.0/MangroveOrder.json";
+import { getLatestMangrovePerNetwork } from "./core";
 
-import { DeploymentFilter, VersionDeployments } from "./types";
-import { findDeployment } from "./utils";
+import {
+  DeploymentFilter,
+  StratContractsNetworkDeployment,
+  VersionDeployments,
+  VersionNetworkDeployment,
+} from "./types";
+import {
+  findAllDeploymentsPerNetwork,
+  findDeployment,
+  findLatestDeploymentPerNetwork,
+} from "./utils";
 
-// This is a sorted array (newest to oldest), exported for tests
+//////////////////////////
+// AaveKandelSeeder
+
+/** This is a sorted array (newest to oldest), exported for tests */
 export const _aaveKandelSeederDeployments: VersionDeployments[] = [
   AaveKandelSeeder_v1_0_0,
 ];
@@ -19,7 +32,24 @@ export const getAaveKandelSeederVersionDeployments = (
   return findDeployment(filter, _aaveKandelSeederDeployments);
 };
 
-// This is a sorted array (newest to oldest), exported for tests
+/** Returns all AaveKandelSeeder deployments matching the filter, grouped by network. */
+export const getAllAaveKandelSeederVersionDeploymentsPerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionDeployments[]> => {
+  return findAllDeploymentsPerNetwork(filter, _aaveKandelSeederDeployments);
+};
+
+/** Returns the latest AaveKandelSeeder deployment matching the filter for each network. */
+export const getLatestAaveKandelSeederPerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionNetworkDeployment> => {
+  return findLatestDeploymentPerNetwork(filter, _aaveKandelSeederDeployments);
+};
+
+//////////////////////////
+// AavePooledRouter
+
+/** This is a sorted array (newest to oldest), exported for tests */
 export const _aavePooledRouterDeployments: VersionDeployments[] = [
   AavePooledRouter_v1_0_0,
 ];
@@ -30,7 +60,24 @@ export const getAavePooledRouterVersionDeployments = (
   return findDeployment(filter, _aavePooledRouterDeployments);
 };
 
-// This is a sorted array (newest to oldest), exported for tests
+/** Returns all AavePooledRouter deployments matching the filter, grouped by network. */
+export const getAllAavePooledRouterVersionDeploymentsPerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionDeployments[]> => {
+  return findAllDeploymentsPerNetwork(filter, _aavePooledRouterDeployments);
+};
+
+/** Returns the latest AaveKandelSeeder deployment matching the filter for each network. */
+export const getLatestAavePooledRouterPerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionNetworkDeployment> => {
+  return findLatestDeploymentPerNetwork(filter, _aavePooledRouterDeployments);
+};
+
+//////////////////////////
+// KandelLib
+
+/** This is a sorted array (newest to oldest), exported for tests */
 export const _kandelLibDeployments: VersionDeployments[] = [KandelLib_v1_0_0];
 
 export const getKandelLibVersionDeployments = (
@@ -39,7 +86,24 @@ export const getKandelLibVersionDeployments = (
   return findDeployment(filter, _kandelLibDeployments);
 };
 
-// This is a sorted array (newest to oldest), exported for tests
+/** Returns all KandelLib deployments matching the filter, grouped by network. */
+export const getAllKandelLibVersionDeploymentsPerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionDeployments[]> => {
+  return findAllDeploymentsPerNetwork(filter, _kandelLibDeployments);
+};
+
+/** Returns the latest AaveKandelSeeder deployment matching the filter for each network. */
+export const getLatestKandelLibPerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionNetworkDeployment> => {
+  return findLatestDeploymentPerNetwork(filter, _kandelLibDeployments);
+};
+
+//////////////////////////
+// KandelSeeder
+
+/** This is a sorted array (newest to oldest), exported for tests */
 export const _kandelSeederDeployments: VersionDeployments[] = [
   KandelSeeder_v1_0_0,
 ];
@@ -50,7 +114,24 @@ export const getKandelSeederVersionDeployments = (
   return findDeployment(filter, _kandelSeederDeployments);
 };
 
-// This is a sorted array (newest to oldest), exported for tests
+/** Returns all KandelSeeder deployments matching the filter, grouped by network. */
+export const getAllKandelSeederVersionDeploymentsPerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionDeployments[]> => {
+  return findAllDeploymentsPerNetwork(filter, _kandelSeederDeployments);
+};
+
+/** Returns the latest AaveKandelSeeder deployment matching the filter for each network. */
+export const getLatestKandelSeederPerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionNetworkDeployment> => {
+  return findLatestDeploymentPerNetwork(filter, _kandelSeederDeployments);
+};
+
+//////////////////////////
+// MangroveOrderRouter
+
+/** This is a sorted array (newest to oldest), exported for tests */
 export const _mangroveOrderRouterDeployments: VersionDeployments[] = [
   MangroveOrderRouter_v1_0_0,
 ];
@@ -61,7 +142,27 @@ export const getMangroveOrderRouterVersionDeployments = (
   return findDeployment(filter, _mangroveOrderRouterDeployments);
 };
 
-// This is a sorted array (newest to oldest), exported for tests
+/** Returns all MangroveOrderRouter deployments matching the filter, grouped by network. */
+export const getAllMangroveOrderRouterVersionDeploymentsPerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionDeployments[]> => {
+  return findAllDeploymentsPerNetwork(filter, _mangroveOrderRouterDeployments);
+};
+
+/** Returns the latest AaveKandelSeeder deployment matching the filter for each network. */
+export const getLatestMangroveOrderRouterPerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionNetworkDeployment> => {
+  return findLatestDeploymentPerNetwork(
+    filter,
+    _mangroveOrderRouterDeployments,
+  );
+};
+
+//////////////////////////
+// MangroveOrder
+
+/** This is a sorted array (newest to oldest), exported for tests */
 export const _mangroveOrderDeployments: VersionDeployments[] = [
   MangroveOrder_v1_0_0,
 ];
@@ -72,16 +173,59 @@ export const getMangroveOrderVersionDeployments = (
   return findDeployment(filter, _mangroveOrderDeployments);
 };
 
-// This is a temporary utility function to get deployments for all the contracts in one go
-export const getStratsContractsVersionDeployments = (
+/** Returns all MangroveOrder deployments matching the filter, grouped by network. */
+export const getAllMangroveOrderVersionDeploymentsPerNetwork = (
   filter?: DeploymentFilter,
-): VersionDeployments[] => {
-  return [
-    getAaveKandelSeederVersionDeployments(filter),
-    getAavePooledRouterVersionDeployments(filter),
-    getKandelLibVersionDeployments(filter),
-    getKandelSeederVersionDeployments(filter),
-    getMangroveOrderRouterVersionDeployments(filter),
-    getMangroveOrderVersionDeployments(filter),
-  ].filter((x): x is VersionDeployments => x !== undefined);
+): Record<string, VersionDeployments[]> => {
+  return findAllDeploymentsPerNetwork(filter, _mangroveOrderDeployments);
+};
+
+/** Returns the latest AaveKandelSeeder deployment matching the filter for each network. */
+export const getLatestMangroveOrderPerNetwork = (
+  filter?: DeploymentFilter,
+): Record<string, VersionNetworkDeployment> => {
+  return findLatestDeploymentPerNetwork(filter, _mangroveOrderDeployments);
+};
+
+//////////////////////////
+// Cross-cutting
+
+/** Get the latest latest strat contract deployments for the latest Mangrove deployment for each network.
+ */
+export const getLatestStratContractsPerNetwork = (
+  filter?: DeploymentFilter,
+  mangroveFilter?: DeploymentFilter,
+): Record<string, StratContractsNetworkDeployment> => {
+  const latestMangrovePerNetwork = getLatestMangrovePerNetwork(mangroveFilter);
+  const latestStratContractsPerNetwork: Record<
+    string,
+    StratContractsNetworkDeployment
+  > = {};
+  const filterDependenciesWithoutMangrove =
+    filter?.dependencies?.filter((d) => d.name !== "Mangrove") ?? [];
+  for (const [network, mangroveDeployment] of Object.entries(
+    latestMangrovePerNetwork,
+  )) {
+    const stratFilter = {
+      ...filter,
+      network,
+      dependencies: [
+        ...filterDependenciesWithoutMangrove,
+        { name: "Mangrove", address: mangroveDeployment.address },
+      ],
+    };
+    latestStratContractsPerNetwork[network] = {
+      mangrove: mangroveDeployment,
+      aaveKandelSeeder:
+        getLatestAaveKandelSeederPerNetwork(stratFilter)[network],
+      aavePooledRouter:
+        getLatestAavePooledRouterPerNetwork(stratFilter)[network],
+      kandelLib: getLatestKandelLibPerNetwork(stratFilter)[network],
+      kandelSeeder: getLatestKandelSeederPerNetwork(stratFilter)[network],
+      mangroveOrderRouter:
+        getLatestMangroveOrderRouterPerNetwork(stratFilter)[network],
+      mangroveOrder: getLatestMangroveOrderPerNetwork(stratFilter)[network],
+    };
+  }
+  return latestStratContractsPerNetwork;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,12 +12,15 @@ export type AddressAndDependencies = {
   dependencies?: Dependency[];
 };
 
-export type VersionDeployments = {
+export type VersionDeploymentBaseInfo = {
   contractName: string;
   deploymentName?: string;
   version: string;
   released: boolean;
   abi: any[];
+};
+
+export type VersionDeployments = VersionDeploymentBaseInfo & {
   networkAddresses: Record<
     string,
     {
@@ -25,6 +28,30 @@ export type VersionDeployments = {
       allAddresses: AddressAndDependencies[];
     }
   >;
+};
+
+export type VersionNetworkDeployment = VersionDeploymentBaseInfo & {
+  network: string;
+  address: string;
+  dependencies?: Dependency[];
+};
+
+/** A deployment of the core contracts on a network. */
+export type CoreContractsNetworkDeployment = {
+  mangrove: VersionNetworkDeployment;
+  mgvOracle?: VersionNetworkDeployment;
+  mgvReader?: VersionNetworkDeployment;
+};
+
+/** A deployment of the strat contracts on a network for a specific Mangrove deployment. */
+export type StratContractsNetworkDeployment = {
+  mangrove: VersionNetworkDeployment;
+  aaveKandelSeeder?: VersionNetworkDeployment;
+  aavePooledRouter?: VersionNetworkDeployment;
+  kandelLib?: VersionNetworkDeployment;
+  kandelSeeder?: VersionNetworkDeployment;
+  mangroveOrderRouter?: VersionNetworkDeployment;
+  mangroveOrder?: VersionNetworkDeployment;
 };
 
 export type DeploymentFilter = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,8 +50,15 @@ function createFilterFunction(criteria: DeploymentFilter) {
     }
     if (
       criteriaWithDefaults.dependencies &&
-      Object.values(deployment.networkAddresses)
-        .flatMap((n) => n.allAddresses.map((a) => a.dependencies))
+      Object.entries(deployment.networkAddresses)
+        .filter(
+          ([network]) =>
+            !criteriaWithDefaults.network ||
+            network == criteriaWithDefaults.network,
+        )
+        .flatMap(([, deployments]) =>
+          deployments.allAddresses.map((a) => a.dependencies),
+        )
         .every(
           (d) => !doDependenciesMatch(d, criteriaWithDefaults.dependencies),
         )

--- a/test/unit/core.unit.test.ts
+++ b/test/unit/core.unit.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import { describe, it } from "mocha";
+import { expect } from "chai";
 
 import Mangrove_v2_0_1 from "../../src/assets/core/v2.0.1/Mangrove.json";
 import MgvReader_v2_0_1 from "../../src/assets/core/v2.0.1/MgvReader.json";
@@ -9,38 +10,173 @@ import {
   getMangroveVersionDeployments,
   getMgvReaderVersionDeployments,
   getMgvOracleVersionDeployments,
+  getAllMangroveVersionDeploymentsPerNetwork,
+  getLatestMangrovePerNetwork,
+  getAllMgvReaderVersionDeploymentsPerNetwork,
+  getLatestMgvReaderPerNetwork,
+  getAllMgvOracleVersionDeploymentsPerNetwork,
+  getLatestMgvOraclePerNetwork,
+  getLatestCoreContractsPerNetwork,
 } from "../../src/core";
+import { firstVersionDeploymentsToVersionNetworkDeployment } from "./unitTestUtil";
 
 describe("core.ts", () => {
-  describe("getMangroveVersionDeployments", () => {
-    it("should find the latest deployment first", () => {
-      const result = getMangroveVersionDeployments({ released: undefined });
-      assert.equal(result, Mangrove_v2_0_1);
-      // NB: Add older old versions here
-      [].forEach((version) => {
-        assert.notEqual(result, version);
+  describe("Mangrove contract", () => {
+    describe("getMangroveVersionDeployments", () => {
+      it("should find the latest deployment first", () => {
+        const result = getMangroveVersionDeployments({ released: undefined });
+        assert.equal(result, Mangrove_v2_0_1);
+        // NB: Add older old versions here
+        [].forEach((version) => {
+          assert.notEqual(result, version);
+        });
+      });
+    });
+
+    describe("getAllMangroveVersionDeploymentsPerNetwork", () => {
+      it("should return all deployments grouped by network", () => {
+        expect(
+          getAllMangroveVersionDeploymentsPerNetwork({ released: undefined }),
+        ).to.deep.equal({
+          "80001": [Mangrove_v2_0_1],
+          "11155111": [Mangrove_v2_0_1],
+        });
+      });
+    });
+
+    describe("getLatestMangrovePerNetwork", () => {
+      it("should return the latest deployment for each network", () => {
+        expect(
+          getLatestMangrovePerNetwork({ released: undefined }),
+        ).to.deep.equal({
+          "80001": firstVersionDeploymentsToVersionNetworkDeployment(
+            Mangrove_v2_0_1,
+            "80001",
+          ),
+          "11155111": firstVersionDeploymentsToVersionNetworkDeployment(
+            Mangrove_v2_0_1,
+            "11155111",
+          ),
+        });
       });
     });
   });
 
-  describe("getMgvReaderVersionDeployments", () => {
-    it("should find the latest deployment first", () => {
-      const result = getMgvReaderVersionDeployments({ released: undefined });
-      assert.equal(result, MgvReader_v2_0_1);
-      // NB: Add older old versions here
-      [].forEach((version) => {
-        assert.notEqual(result, version);
+  describe("MgvReader contract", () => {
+    describe("getMgvReaderVersionDeployments", () => {
+      it("should find the latest deployment first", () => {
+        const result = getMgvReaderVersionDeployments({ released: undefined });
+        assert.equal(result, MgvReader_v2_0_1);
+        // NB: Add older old versions here
+        [].forEach((version) => {
+          assert.notEqual(result, version);
+        });
+      });
+    });
+
+    describe("getAllMgvReaderVersionDeploymentsPerNetwork", () => {
+      it("should return all deployments grouped by network", () => {
+        expect(
+          getAllMgvReaderVersionDeploymentsPerNetwork({ released: undefined }),
+        ).to.deep.equal({
+          "80001": [MgvReader_v2_0_1],
+          "11155111": [MgvReader_v2_0_1],
+        });
+      });
+    });
+
+    describe("getLatestMgvReaderPerNetwork", () => {
+      it("should return the latest deployment for each network", () => {
+        expect(
+          getLatestMgvReaderPerNetwork({ released: undefined }),
+        ).to.deep.equal({
+          "80001": firstVersionDeploymentsToVersionNetworkDeployment(
+            MgvReader_v2_0_1,
+            "80001",
+          ),
+          "11155111": firstVersionDeploymentsToVersionNetworkDeployment(
+            MgvReader_v2_0_1,
+            "11155111",
+          ),
+        });
       });
     });
   });
 
-  describe("getMgvOracleVersionDeployments", () => {
-    it("should find the latest deployment first", () => {
-      const result = getMgvOracleVersionDeployments({ released: undefined });
-      assert.equal(result, MgvOracle_v2_0_1);
-      // NB: Add older old versions here
-      [].forEach((version) => {
-        assert.notEqual(result, version);
+  describe("MgvOracle contract", () => {
+    describe("getMgvOracleVersionDeployments", () => {
+      it("should find the latest deployment first", () => {
+        const result = getMgvOracleVersionDeployments({ released: undefined });
+        assert.equal(result, MgvOracle_v2_0_1);
+        // NB: Add older old versions here
+        [].forEach((version) => {
+          assert.notEqual(result, version);
+        });
+      });
+    });
+
+    describe("getAllMgvOracleVersionDeploymentsPerNetwork", () => {
+      it("should return all deployments grouped by network", () => {
+        expect(
+          getAllMgvOracleVersionDeploymentsPerNetwork({ released: undefined }),
+        ).to.deep.equal({
+          "80001": [MgvOracle_v2_0_1],
+          "11155111": [MgvOracle_v2_0_1],
+        });
+      });
+    });
+
+    describe("getLatestMgvOraclePerNetwork", () => {
+      it("should return the latest deployment for each network", () => {
+        expect(
+          getLatestMgvOraclePerNetwork({ released: undefined }),
+        ).to.deep.equal({
+          "80001": firstVersionDeploymentsToVersionNetworkDeployment(
+            MgvOracle_v2_0_1,
+            "80001",
+          ),
+          "11155111": firstVersionDeploymentsToVersionNetworkDeployment(
+            MgvOracle_v2_0_1,
+            "11155111",
+          ),
+        });
+      });
+    });
+  });
+
+  describe("getLatestCoreContractsPerNetwork", () => {
+    it("should return the latest deployments for each network", () => {
+      expect(
+        getLatestCoreContractsPerNetwork({ released: undefined }),
+      ).to.deep.equal({
+        "80001": {
+          mangrove: firstVersionDeploymentsToVersionNetworkDeployment(
+            Mangrove_v2_0_1,
+            "80001",
+          ),
+          mgvOracle: firstVersionDeploymentsToVersionNetworkDeployment(
+            MgvOracle_v2_0_1,
+            "80001",
+          ),
+          mgvReader: firstVersionDeploymentsToVersionNetworkDeployment(
+            MgvReader_v2_0_1,
+            "80001",
+          ),
+        },
+        "11155111": {
+          mangrove: firstVersionDeploymentsToVersionNetworkDeployment(
+            Mangrove_v2_0_1,
+            "11155111",
+          ),
+          mgvOracle: firstVersionDeploymentsToVersionNetworkDeployment(
+            MgvOracle_v2_0_1,
+            "11155111",
+          ),
+          mgvReader: firstVersionDeploymentsToVersionNetworkDeployment(
+            MgvReader_v2_0_1,
+            "11155111",
+          ),
+        },
       });
     });
   });

--- a/test/unit/strats.unit.test.ts
+++ b/test/unit/strats.unit.test.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import { describe, it } from "mocha";
 
+import Mangrove_v2_0_1 from "../../src/assets/core/v2.0.1/Mangrove.json";
 import AaveKandelSeeder_v1_0_0 from "../../src/assets/strats/v1.0.0/AaveKandelSeeder.json";
 import AavePooledRouter_v1_0_0 from "../../src/assets/strats/v1.0.0/AavePooledRouter.json";
 import KandelLib_v1_0_0 from "../../src/assets/strats/v1.0.0/KandelLib.json";
@@ -11,104 +12,313 @@ import MangroveOrder_v1_0_0 from "../../src/assets/strats/v1.0.0/MangroveOrder.j
 import {
   getAaveKandelSeederVersionDeployments,
   getAavePooledRouterVersionDeployments,
+  getAllAaveKandelSeederVersionDeploymentsPerNetwork,
+  getAllAavePooledRouterVersionDeploymentsPerNetwork,
+  getAllKandelLibVersionDeploymentsPerNetwork,
+  getAllKandelSeederVersionDeploymentsPerNetwork,
+  getAllMangroveOrderRouterVersionDeploymentsPerNetwork,
+  getAllMangroveOrderVersionDeploymentsPerNetwork,
   getKandelLibVersionDeployments,
   getKandelSeederVersionDeployments,
+  getLatestAaveKandelSeederPerNetwork,
+  getLatestAavePooledRouterPerNetwork,
+  getLatestKandelLibPerNetwork,
+  getLatestKandelSeederPerNetwork,
+  getLatestMangroveOrderPerNetwork,
+  getLatestMangroveOrderRouterPerNetwork,
+  getLatestStratContractsPerNetwork,
   getMangroveOrderRouterVersionDeployments,
   getMangroveOrderVersionDeployments,
-  getStratsContractsVersionDeployments,
 } from "../../src/strats";
+import { expect } from "chai";
+import { firstVersionDeploymentsToVersionNetworkDeployment } from "./unitTestUtil";
 
 describe("strats.ts", () => {
-  describe("getAaveKandelSeederVersionDeployments", () => {
-    it("should find the latest deployment first", () => {
-      const result = getAaveKandelSeederVersionDeployments({
-        released: undefined,
+  describe("AaveKandelSeeder contract", () => {
+    describe("getAaveKandelSeederVersionDeployments", () => {
+      it("should find the latest deployment first", () => {
+        const result = getAaveKandelSeederVersionDeployments({
+          released: undefined,
+        });
+        assert.equal(result, AaveKandelSeeder_v1_0_0);
+        // NB: Add older old versions here
+        [].forEach((version) => {
+          assert.notEqual(result, version);
+        });
       });
-      assert.equal(result, AaveKandelSeeder_v1_0_0);
-      // NB: Add older old versions here
-      [].forEach((version) => {
-        assert.notEqual(result, version);
+    });
+
+    describe("getAllAaveKandelSeederVersionDeploymentsPerNetwork", () => {
+      it("should return all deployments grouped by network", () => {
+        expect(
+          getAllAaveKandelSeederVersionDeploymentsPerNetwork({
+            released: undefined,
+          }),
+        ).to.deep.equal({
+          "80001": [AaveKandelSeeder_v1_0_0],
+        });
+      });
+    });
+
+    describe("getLatestAaveKandelSeederPerNetwork", () => {
+      it("should return the latest deployment for each network", () => {
+        expect(
+          getLatestAaveKandelSeederPerNetwork({ released: undefined }),
+        ).to.deep.equal({
+          "80001": firstVersionDeploymentsToVersionNetworkDeployment(
+            AaveKandelSeeder_v1_0_0,
+            "80001",
+          ),
+        });
       });
     });
   });
 
-  describe("getAavePooledRouterVersionDeployments", () => {
-    it("should find the latest deployment first", () => {
-      const result = getAavePooledRouterVersionDeployments({
-        released: undefined,
+  describe("AavePooledRouter contract", () => {
+    describe("getAavePooledRouterVersionDeployments", () => {
+      it("should find the latest deployment first", () => {
+        const result = getAavePooledRouterVersionDeployments({
+          released: undefined,
+        });
+        assert.equal(result, AavePooledRouter_v1_0_0);
+        // NB: Add older old versions here
+        [].forEach((version) => {
+          assert.notEqual(result, version);
+        });
       });
-      assert.equal(result, AavePooledRouter_v1_0_0);
-      // NB: Add older old versions here
-      [].forEach((version) => {
-        assert.notEqual(result, version);
+    });
+
+    describe("getAllAavePooledRouterVersionDeploymentsPerNetwork", () => {
+      it("should return all deployments grouped by network", () => {
+        expect(
+          getAllAavePooledRouterVersionDeploymentsPerNetwork({
+            released: undefined,
+          }),
+        ).to.deep.equal({
+          "80001": [AavePooledRouter_v1_0_0],
+        });
+      });
+    });
+
+    describe("getLatestAavePooledRouterPerNetwork", () => {
+      it("should return the latest deployment for each network", () => {
+        expect(
+          getLatestAavePooledRouterPerNetwork({ released: undefined }),
+        ).to.deep.equal({
+          "80001": firstVersionDeploymentsToVersionNetworkDeployment(
+            AavePooledRouter_v1_0_0,
+            "80001",
+          ),
+        });
       });
     });
   });
 
-  describe("getKandelLibVersionDeployments", () => {
-    it("should find the latest deployment first", () => {
-      const result = getKandelLibVersionDeployments({ released: undefined });
-      assert.equal(result, KandelLib_v1_0_0);
-      // NB: Add older old versions here
-      [].forEach((version) => {
-        assert.notEqual(result, version);
+  describe("KandelLib contract", () => {
+    describe("getKandelLibVersionDeployments", () => {
+      it("should find the latest deployment first", () => {
+        const result = getKandelLibVersionDeployments({ released: undefined });
+        assert.equal(result, KandelLib_v1_0_0);
+        // NB: Add older old versions here
+        [].forEach((version) => {
+          assert.notEqual(result, version);
+        });
+      });
+    });
+
+    describe("getAllKandelLibVersionDeploymentsPerNetwork", () => {
+      it("should return all deployments grouped by network", () => {
+        expect(
+          getAllKandelLibVersionDeploymentsPerNetwork({ released: undefined }),
+        ).to.deep.equal({
+          "80001": [KandelLib_v1_0_0],
+        });
+      });
+    });
+
+    describe("getLatestKandelLibPerNetwork", () => {
+      it("should return the latest deployment for each network", () => {
+        expect(
+          getLatestKandelLibPerNetwork({ released: undefined }),
+        ).to.deep.equal({
+          "80001": firstVersionDeploymentsToVersionNetworkDeployment(
+            KandelLib_v1_0_0,
+            "80001",
+          ),
+        });
       });
     });
   });
 
-  describe("getKandelSeederVersionDeployments", () => {
-    it("should find the latest deployment first", () => {
-      const result = getKandelSeederVersionDeployments({ released: undefined });
-      assert.equal(result, KandelSeeder_v1_0_0);
-      // NB: Add older old versions here
-      [].forEach((version) => {
-        assert.notEqual(result, version);
+  describe("KandelSeeder contract", () => {
+    describe("getKandelSeederVersionDeployments", () => {
+      it("should find the latest deployment first", () => {
+        const result = getKandelSeederVersionDeployments({
+          released: undefined,
+        });
+        assert.equal(result, KandelSeeder_v1_0_0);
+        // NB: Add older old versions here
+        [].forEach((version) => {
+          assert.notEqual(result, version);
+        });
+      });
+    });
+
+    describe("getAllKandelSeederVersionDeploymentsPerNetwork", () => {
+      it("should return all deployments grouped by network", () => {
+        expect(
+          getAllKandelSeederVersionDeploymentsPerNetwork({
+            released: undefined,
+          }),
+        ).to.deep.equal({
+          "80001": [KandelSeeder_v1_0_0],
+        });
+      });
+    });
+
+    describe("getLatestKandelSeederPerNetwork", () => {
+      it("should return the latest deployment for each network", () => {
+        expect(
+          getLatestKandelSeederPerNetwork({ released: undefined }),
+        ).to.deep.equal({
+          "80001": firstVersionDeploymentsToVersionNetworkDeployment(
+            KandelSeeder_v1_0_0,
+            "80001",
+          ),
+        });
       });
     });
   });
 
-  describe("getMangroveOrderRouterVersionDeployments", () => {
-    it("should find the latest deployment first", () => {
-      const result = getMangroveOrderRouterVersionDeployments({
-        released: undefined,
+  describe("MangroveOrderRouter contract", () => {
+    describe("getMangroveOrderRouterVersionDeployments", () => {
+      it("should find the latest deployment first", () => {
+        const result = getMangroveOrderRouterVersionDeployments({
+          released: undefined,
+        });
+        assert.equal(result, MangroveOrderRouter_v1_0_0);
+        // NB: Add older old versions here
+        [].forEach((version) => {
+          assert.notEqual(result, version);
+        });
       });
-      assert.equal(result, MangroveOrderRouter_v1_0_0);
-      // NB: Add older old versions here
-      [].forEach((version) => {
-        assert.notEqual(result, version);
+    });
+
+    describe("getAllMangroveOrderRouterVersionDeploymentsPerNetwork", () => {
+      it("should return all deployments grouped by network", () => {
+        expect(
+          getAllMangroveOrderRouterVersionDeploymentsPerNetwork({
+            released: undefined,
+          }),
+        ).to.deep.equal({
+          "80001": [MangroveOrderRouter_v1_0_0],
+        });
+      });
+    });
+
+    describe("getLatestMangroveOrderRouterPerNetwork", () => {
+      it("should return the latest deployment for each network", () => {
+        expect(
+          getLatestMangroveOrderRouterPerNetwork({ released: undefined }),
+        ).to.deep.equal({
+          "80001": firstVersionDeploymentsToVersionNetworkDeployment(
+            MangroveOrderRouter_v1_0_0,
+            "80001",
+          ),
+        });
       });
     });
   });
 
-  describe("getMangroveOrderVersionDeployments", () => {
-    it("should find the latest deployment first", () => {
-      const result = getMangroveOrderVersionDeployments({
-        released: undefined,
+  describe("MangroveOrder contract", () => {
+    describe("getMangroveOrderVersionDeployments", () => {
+      it("should find the latest deployment first", () => {
+        const result = getMangroveOrderVersionDeployments({
+          released: undefined,
+        });
+        assert.equal(result, MangroveOrder_v1_0_0);
+        // NB: Add older old versions here
+        [].forEach((version) => {
+          assert.notEqual(result, version);
+        });
       });
-      assert.equal(result, MangroveOrder_v1_0_0);
-      // NB: Add older old versions here
-      [].forEach((version) => {
-        assert.notEqual(result, version);
+    });
+
+    describe("getAllMangroveOrderVersionDeploymentsPerNetwork", () => {
+      it("should return all deployments grouped by network", () => {
+        expect(
+          getAllMangroveOrderVersionDeploymentsPerNetwork({
+            released: undefined,
+          }),
+        ).to.deep.equal({
+          "80001": [MangroveOrder_v1_0_0],
+        });
+      });
+    });
+
+    describe("getLatestMangroveOrderPerNetwork", () => {
+      it("should return the latest deployment for each network", () => {
+        expect(
+          getLatestMangroveOrderPerNetwork({ released: undefined }),
+        ).to.deep.equal({
+          "80001": firstVersionDeploymentsToVersionNetworkDeployment(
+            MangroveOrder_v1_0_0,
+            "80001",
+          ),
+        });
       });
     });
   });
 
-  describe("getStratsContractsVersionDeployments", () => {
-    it("should find the latest deployments first", () => {
-      const result = getStratsContractsVersionDeployments({
-        released: undefined,
+  describe("getLatestStratContractsPerNetwork", () => {
+    it("should return the latest deployments for each network", () => {
+      expect(
+        getLatestStratContractsPerNetwork({ released: undefined }),
+      ).to.deep.equal({
+        "80001": {
+          mangrove: firstVersionDeploymentsToVersionNetworkDeployment(
+            Mangrove_v2_0_1,
+            "80001",
+          ),
+          aaveKandelSeeder: firstVersionDeploymentsToVersionNetworkDeployment(
+            AaveKandelSeeder_v1_0_0,
+            "80001",
+          ),
+          aavePooledRouter: firstVersionDeploymentsToVersionNetworkDeployment(
+            AavePooledRouter_v1_0_0,
+            "80001",
+          ),
+          kandelLib: firstVersionDeploymentsToVersionNetworkDeployment(
+            KandelLib_v1_0_0,
+            "80001",
+          ),
+          kandelSeeder: firstVersionDeploymentsToVersionNetworkDeployment(
+            KandelSeeder_v1_0_0,
+            "80001",
+          ),
+          mangroveOrderRouter:
+            firstVersionDeploymentsToVersionNetworkDeployment(
+              MangroveOrderRouter_v1_0_0,
+              "80001",
+            ),
+          mangroveOrder: firstVersionDeploymentsToVersionNetworkDeployment(
+            MangroveOrder_v1_0_0,
+            "80001",
+          ),
+        },
+        "11155111": {
+          mangrove: firstVersionDeploymentsToVersionNetworkDeployment(
+            Mangrove_v2_0_1,
+            "11155111",
+          ),
+          aaveKandelSeeder: undefined,
+          aavePooledRouter: undefined,
+          kandelLib: undefined,
+          kandelSeeder: undefined,
+          mangroveOrderRouter: undefined,
+          mangroveOrder: undefined,
+        },
       });
-
-      const expected = [
-        AaveKandelSeeder_v1_0_0,
-        AavePooledRouter_v1_0_0,
-        KandelLib_v1_0_0,
-        KandelSeeder_v1_0_0,
-        MangroveOrderRouter_v1_0_0,
-        MangroveOrder_v1_0_0,
-      ];
-
-      assert.deepEqual(result, expected);
     });
   });
 });

--- a/test/unit/unitTestUtil.ts
+++ b/test/unit/unitTestUtil.ts
@@ -1,0 +1,16 @@
+import { VersionDeployments, VersionNetworkDeployment } from "../../src/types";
+import { getVersionDeploymentBaseInfo } from "../../src/utils";
+
+export function firstVersionDeploymentsToVersionNetworkDeployment(
+  versionDeployments: VersionDeployments,
+  network: string,
+): VersionNetworkDeployment {
+  return {
+    ...getVersionDeploymentBaseInfo(versionDeployments),
+    network: network,
+    address:
+      versionDeployments.networkAddresses[network].allAddresses[0].address,
+    dependencies:
+      versionDeployments.networkAddresses[network].allAddresses[0].dependencies,
+  };
+}

--- a/test/unit/utils.unit.test.ts
+++ b/test/unit/utils.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "mocha";
 import { expect } from "chai";
 
-import { findDeployment } from "../../src/utils";
+import { findAllDeployments, findDeployment } from "../../src/utils";
 import { VersionDeployments } from "../../src/types";
 
 describe("utils.ts", () => {
@@ -821,6 +821,75 @@ describe("utils.ts", () => {
           testDeploymentsReverse,
         ),
       ).to.be.undefined;
+    });
+  });
+
+  describe("findAllDeployments", () => {
+    it("should handle empty deployments", () => {
+      expect(findAllDeployments(undefined, [])).to.deep.equal([]);
+    });
+
+    it("should return all matching the filter", () => {
+      // Filter variants are assumed covered by findDeployment tests, so only filtering on released here
+
+      const testUnreleasedDeployment: VersionDeployments = {
+        contractName: "",
+        deploymentName: "",
+        version: "",
+        released: false,
+        abi: [],
+        networkAddresses: {
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef", dependencies: [] }],
+          },
+        },
+      };
+      const testReleasedDeployment1: VersionDeployments = {
+        contractName: "",
+        deploymentName: "",
+        version: "",
+        released: true,
+        abi: [],
+        networkAddresses: {
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef", dependencies: [] }],
+          },
+        },
+      };
+      const testReleasedDeployment2: VersionDeployments = {
+        contractName: "",
+        deploymentName: "",
+        version: "",
+        released: true,
+        abi: [],
+        networkAddresses: {
+          "2": {
+            primaryAddress: "0xbeef",
+            allAddresses: [{ address: "0xbeef", dependencies: [] }],
+          },
+        },
+      };
+
+      const testDeployments = [
+        testUnreleasedDeployment,
+        testReleasedDeployment1,
+        testUnreleasedDeployment,
+        testReleasedDeployment2,
+      ];
+
+      expect(
+        findAllDeployments({ released: true }, testDeployments),
+      ).to.deep.equal([testReleasedDeployment1, testReleasedDeployment2]);
+
+      expect(
+        findAllDeployments({ network: "1" }, testDeployments),
+      ).to.deep.equal([testReleasedDeployment1]);
+
+      expect(
+        findAllDeployments({ network: "31337" }, testDeployments),
+      ).to.deep.equal([]);
     });
   });
 });

--- a/test/unit/utils.unit.test.ts
+++ b/test/unit/utils.unit.test.ts
@@ -1,7 +1,13 @@
 import { describe, it } from "mocha";
 import { expect } from "chai";
 
-import { findAllDeployments, findDeployment } from "../../src/utils";
+import {
+  findAllDeployments,
+  findAllDeploymentsPerNetwork,
+  findDeployment,
+  findLatestDeploymentPerNetwork,
+  getVersionDeploymentBaseInfo,
+} from "../../src/utils";
 import { VersionDeployments } from "../../src/types";
 
 describe("utils.ts", () => {
@@ -890,6 +896,290 @@ describe("utils.ts", () => {
       expect(
         findAllDeployments({ network: "31337" }, testDeployments),
       ).to.deep.equal([]);
+    });
+  });
+});
+
+describe("findAllDeploymentsPerNetwork", () => {
+  it("should handle empty deployments", () => {
+    expect(findAllDeploymentsPerNetwork(undefined, [])).to.deep.equal({});
+  });
+
+  it("should filter", () => {
+    // Filter variants are assumed covered by findDeployment tests,
+    // so this only validates that filtering is applied
+
+    const testUnreleasedDeployment: VersionDeployments = {
+      contractName: "",
+      deploymentName: "",
+      version: "",
+      released: false,
+      abi: [],
+      networkAddresses: {
+        "1": {
+          primaryAddress: "0xbeef",
+          allAddresses: [{ address: "0xbeef", dependencies: [] }],
+        },
+      },
+    };
+    const testReleasedDeployment: VersionDeployments = {
+      contractName: "",
+      deploymentName: "",
+      version: "",
+      released: true,
+      abi: [],
+      networkAddresses: {
+        "1": {
+          primaryAddress: "0xbeef",
+          allAddresses: [{ address: "0xbeef", dependencies: [] }],
+        },
+      },
+    };
+
+    const testDeployments = [testUnreleasedDeployment, testReleasedDeployment];
+
+    expect(
+      findAllDeploymentsPerNetwork({ released: true }, testDeployments),
+    ).to.deep.equal({
+      "1": [testReleasedDeployment],
+    });
+  });
+
+  it("should return full version deployment structure for all listed networks", () => {
+    const testReleasedDeployment: VersionDeployments = {
+      contractName: "",
+      deploymentName: "",
+      version: "",
+      released: true,
+      abi: [],
+      networkAddresses: {
+        "1": {
+          primaryAddress: "0xbeef",
+          allAddresses: [{ address: "0xbeef", dependencies: [] }],
+        },
+        "2": {
+          primaryAddress: "0xbeef",
+          allAddresses: [{ address: "0xbeef", dependencies: [] }],
+        },
+      },
+    };
+
+    const testDeployments = [testReleasedDeployment];
+
+    expect(
+      findAllDeploymentsPerNetwork({ released: true }, testDeployments),
+    ).to.deep.equal({
+      "1": [testReleasedDeployment],
+      "2": [testReleasedDeployment],
+    });
+  });
+
+  it("should return all version deployments for a network", () => {
+    const testReleasedDeployment1: VersionDeployments = {
+      contractName: "",
+      deploymentName: "",
+      version: "1",
+      released: true,
+      abi: [],
+      networkAddresses: {
+        "1": {
+          primaryAddress: "0xbeef",
+          allAddresses: [{ address: "0xbeef", dependencies: [] }],
+        },
+        "2": {
+          primaryAddress: "0xbeef",
+          allAddresses: [{ address: "0xbeef", dependencies: [] }],
+        },
+      },
+    };
+    const testReleasedDeployment2: VersionDeployments = {
+      contractName: "",
+      deploymentName: "",
+      version: "2",
+      released: true,
+      abi: [],
+      networkAddresses: {
+        "1": {
+          primaryAddress: "0xbeef",
+          allAddresses: [{ address: "0xbeef", dependencies: [] }],
+        },
+      },
+    };
+
+    const testDeployments = [testReleasedDeployment2, testReleasedDeployment1];
+
+    expect(
+      findAllDeploymentsPerNetwork({ released: true }, testDeployments),
+    ).to.deep.equal({
+      "1": [testReleasedDeployment2, testReleasedDeployment1],
+      "2": [testReleasedDeployment1],
+    });
+  });
+});
+
+describe("getVersionDeploymentBaseInfo", () => {
+  it("should return the correct base info", () => {
+    const testReleasedDeployment: VersionDeployments = {
+      contractName: "a",
+      deploymentName: "b",
+      version: "1",
+      released: true,
+      abi: [{ foo: "bar" }],
+      networkAddresses: {
+        "1": {
+          primaryAddress: "0xbeef",
+          allAddresses: [
+            {
+              address: "0xbeef",
+              dependencies: [{ name: "dep", address: "0xcode" }],
+            },
+          ],
+        },
+      },
+    };
+
+    expect(getVersionDeploymentBaseInfo(testReleasedDeployment)).to.deep.equal({
+      contractName: "a",
+      deploymentName: "b",
+      version: "1",
+      released: true,
+      abi: [{ foo: "bar" }],
+    });
+  });
+});
+
+describe("findLatestDeploymentPerNetwork", () => {
+  it("should handle empty deployments", () => {
+    expect(findLatestDeploymentPerNetwork(undefined, [])).to.deep.equal({});
+  });
+
+  it("should filter and return latest deployment satisfying dependencies", () => {
+    const testUnreleasedDeployment: VersionDeployments = {
+      contractName: "a",
+      deploymentName: "b",
+      version: "2",
+      released: false,
+      abi: [{ foo: "bar" }],
+      networkAddresses: {
+        "1": {
+          primaryAddress: "0xfeeb1",
+          allAddresses: [
+            {
+              address: "0xfeeb1",
+              dependencies: [{ name: "dep", address: "0xodec" }],
+            },
+            {
+              address: "0xfeeb2",
+              dependencies: [{ name: "dep", address: "0xcode" }],
+            },
+            {
+              address: "0xfeeb3",
+              dependencies: [{ name: "dep", address: "0xcode" }],
+            },
+          ],
+        },
+      },
+    };
+
+    const testReleasedDeployment: VersionDeployments = {
+      contractName: "a",
+      deploymentName: "b",
+      version: "1",
+      released: true,
+      abi: [{ foo: "bar" }],
+      networkAddresses: {
+        "1": {
+          primaryAddress: "0xbeef1",
+          allAddresses: [
+            {
+              address: "0xbeef1",
+              dependencies: [{ name: "dep", address: "0xodec" }],
+            },
+            {
+              address: "0xbeef2",
+              dependencies: [{ name: "dep", address: "0xcode" }],
+            },
+            {
+              address: "0xbeef3",
+              dependencies: [{ name: "dep", address: "0xcode" }],
+            },
+          ],
+        },
+      },
+    };
+
+    const testDeployments = [testUnreleasedDeployment, testReleasedDeployment];
+
+    expect(
+      findLatestDeploymentPerNetwork(
+        { released: true, dependencies: [{ name: "dep", address: "0xcode" }] },
+        testDeployments,
+      ),
+    ).to.deep.equal({
+      "1": {
+        ...getVersionDeploymentBaseInfo(testReleasedDeployment),
+        network: "1",
+        address:
+          testReleasedDeployment.networkAddresses["1"].allAddresses[1].address,
+        dependencies:
+          testReleasedDeployment.networkAddresses["1"].allAddresses[1]
+            .dependencies,
+      },
+    });
+  });
+
+  it("should handle multiple networks", () => {
+    const testReleasedDeployment: VersionDeployments = {
+      contractName: "a",
+      deploymentName: "b",
+      version: "1",
+      released: true,
+      abi: [{ foo: "bar" }],
+      networkAddresses: {
+        "1": {
+          primaryAddress: "0xbeef1",
+          allAddresses: [
+            {
+              address: "0xbeef1",
+              dependencies: [{ name: "dep", address: "0xcode1" }],
+            },
+          ],
+        },
+        "2": {
+          primaryAddress: "0xbeef2",
+          allAddresses: [
+            {
+              address: "0xbeef2",
+              dependencies: [{ name: "dep", address: "0xcode2" }],
+            },
+          ],
+        },
+      },
+    };
+
+    const testDeployments = [testReleasedDeployment];
+
+    expect(
+      findLatestDeploymentPerNetwork({ released: true }, testDeployments),
+    ).to.deep.equal({
+      "1": {
+        ...getVersionDeploymentBaseInfo(testReleasedDeployment),
+        network: "1",
+        address:
+          testReleasedDeployment.networkAddresses["1"].allAddresses[0].address,
+        dependencies:
+          testReleasedDeployment.networkAddresses["1"].allAddresses[0]
+            .dependencies,
+      },
+      "2": {
+        ...getVersionDeploymentBaseInfo(testReleasedDeployment),
+        network: "2",
+        address:
+          testReleasedDeployment.networkAddresses["2"].allAddresses[0].address,
+        dependencies:
+          testReleasedDeployment.networkAddresses["2"].allAddresses[0]
+            .dependencies,
+      },
     });
   });
 });

--- a/test/unit/utils.unit.test.ts
+++ b/test/unit/utils.unit.test.ts
@@ -254,7 +254,7 @@ describe("utils.ts", () => {
         contractName: "",
         deploymentName: "1",
         version: "1.2.3",
-        released: true, // Default filter value
+        released: true,
         abi: [],
         networkAddresses: {
           "1": {
@@ -275,7 +275,7 @@ describe("utils.ts", () => {
         contractName: "",
         deploymentName: "2",
         version: "2.0.0",
-        released: true, // Default filter value
+        released: true,
         abi: [],
         networkAddresses: {
           "1": {
@@ -289,21 +289,57 @@ describe("utils.ts", () => {
           },
         },
       };
+      const testReleasedDeployment3: VersionDeployments = {
+        contractName: "",
+        deploymentName: "2",
+        version: "2.0.0",
+        released: true,
+        abi: [],
+        networkAddresses: {
+          "1": {
+            primaryAddress: "0xbeef",
+            allAddresses: [
+              {
+                address: "0xbeef",
+                dependencies: [{ name: "dep1", address: "0xodec" }],
+              },
+            ],
+          },
+          "2": {
+            primaryAddress: "0xbeef",
+            allAddresses: [
+              {
+                address: "0xbeef",
+                dependencies: [{ name: "dep1", address: "0xcode" }],
+              },
+            ],
+          },
+        },
+      };
 
       const testDeployments = [
+        testReleasedDeployment3,
         testReleasedDeployment2,
         testReleasedDeployment1,
       ];
 
       // No dependencies required
       expect(findDeployment({ dependencies: [] }, testDeployments)).to.equal(
-        testReleasedDeployment2,
+        testReleasedDeployment3,
       );
 
       // Chronological deployments
       expect(
         findDeployment(
           { dependencies: [{ name: "dep1", address: "0xcode" }] },
+          testDeployments,
+        ),
+      ).to.equal(testReleasedDeployment3);
+
+      // Dependencies respects network
+      expect(
+        findDeployment(
+          { network: "1", dependencies: [{ name: "dep1", address: "0xcode" }] },
           testDeployments,
         ),
       ).to.equal(testReleasedDeployment2);


### PR DESCRIPTION
Incl. methods for getting all periphery and strat contracts for a given/latest Mangrove deployment