### PR TITLE
ops: Add Blast Sepolia deployments of mangrove-strats v2.0.1-0 and v2.1.0-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Next version
 
 - Add deployments of `BlastMangrove`, `MgvOracle`, and `MgvReader` v2.1.0-0 to Blast Sepolia
+- Add deployments of `KandelLib` and `KandelSeeder` v2.0.1-0 to Blast Sepolia
+- Add deployments of `BlastMangroveAmplifier`, `BlastMangroveOrder-Router.json`, `BlastMangroveOrder`, and `BlastRouterProxyFactory` v2.1.0-0 to Blast Sepolia
 
 # 2.0.3-2
 

--- a/src/assets/strats/v2.0.1-0/KandelLib.json
+++ b/src/assets/strats/v2.0.1-0/KandelLib.json
@@ -1,0 +1,1420 @@
+{
+  "$schema": "../../../../contract.schema.json",
+  "released": false,
+  "contractName": "Kandel",
+  "deploymentName": "KandelLib",
+  "version": "2.0.1-0",
+  "networkAddresses": {
+    "168587773": {
+      "primaryAddress": "0x00Bf28e29C398C168AAe0532373631fc41a2F77a",
+      "allAddresses": [
+        {
+          "address": "0x00Bf28e29C398C168AAe0532373631fc41a2F77a",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x579ba1708e8E15c9D41143a3da4B8382831E0897"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "mgv",
+          "type": "address",
+          "internalType": "contract IMangrove"
+        },
+        {
+          "name": "olKeyBaseQuote",
+          "type": "tuple",
+          "internalType": "struct OLKey",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "name": "gasreq",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "receive",
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "BASE",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "FUND_OWNER",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "MGV",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract IMangrove"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "QUOTE",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROUTER_IMPLEMENTATION",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "STRICT_PULLING",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "TICK_SPACING",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "activate",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "admin",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "current",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "approve",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        {
+          "name": "spender",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "baseQuoteTickOffset",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "createDistribution",
+      "inputs": [
+        {
+          "name": "from",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "to",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "baseQuoteTickIndex0",
+          "type": "int256",
+          "internalType": "Tick"
+        },
+        {
+          "name": "_baseQuoteTickOffset",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "firstAskIndex",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "bidGives",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "askGives",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "pricePoints",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "stepSize",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "distribution",
+          "type": "tuple",
+          "internalType": "struct DirectWithBidsAndAsksDistribution.Distribution",
+          "components": [
+            {
+              "name": "asks",
+              "type": "tuple[]",
+              "internalType": "struct DirectWithBidsAndAsksDistribution.DistributionOffer[]",
+              "components": [
+                {
+                  "name": "index",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "tick",
+                  "type": "int256",
+                  "internalType": "Tick"
+                },
+                {
+                  "name": "gives",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "bids",
+              "type": "tuple[]",
+              "internalType": "struct DirectWithBidsAndAsksDistribution.DistributionOffer[]",
+              "components": [
+                {
+                  "name": "index",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "tick",
+                  "type": "int256",
+                  "internalType": "Tick"
+                },
+                {
+                  "name": "gives",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "depositFunds",
+      "inputs": [
+        {
+          "name": "baseAmount",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "quoteAmount",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "getOffer",
+      "inputs": [
+        {
+          "name": "ba",
+          "type": "uint8",
+          "internalType": "enum OfferType"
+        },
+        {
+          "name": "index",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "offer",
+          "type": "uint256",
+          "internalType": "Offer"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "indexOfOfferId",
+      "inputs": [
+        {
+          "name": "ba",
+          "type": "uint8",
+          "internalType": "enum OfferType"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "index",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "makerExecute",
+      "inputs": [
+        {
+          "name": "order",
+          "type": "tuple",
+          "internalType": "struct MgvLib.SingleOrder",
+          "components": [
+            {
+              "name": "olKey",
+              "type": "tuple",
+              "internalType": "struct OLKey",
+              "components": [
+                {
+                  "name": "outbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "inbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "tickSpacing",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "offerId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "offer",
+              "type": "uint256",
+              "internalType": "Offer"
+            },
+            {
+              "name": "takerWants",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "takerGives",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "offerDetail",
+              "type": "uint256",
+              "internalType": "OfferDetail"
+            },
+            {
+              "name": "global",
+              "type": "uint256",
+              "internalType": "Global"
+            },
+            {
+              "name": "local",
+              "type": "uint256",
+              "internalType": "Local"
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "ret",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "makerPosthook",
+      "inputs": [
+        {
+          "name": "order",
+          "type": "tuple",
+          "internalType": "struct MgvLib.SingleOrder",
+          "components": [
+            {
+              "name": "olKey",
+              "type": "tuple",
+              "internalType": "struct OLKey",
+              "components": [
+                {
+                  "name": "outbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "inbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "tickSpacing",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "offerId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "offer",
+              "type": "uint256",
+              "internalType": "Offer"
+            },
+            {
+              "name": "takerWants",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "takerGives",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "offerDetail",
+              "type": "uint256",
+              "internalType": "OfferDetail"
+            },
+            {
+              "name": "global",
+              "type": "uint256",
+              "internalType": "Global"
+            },
+            {
+              "name": "local",
+              "type": "uint256",
+              "internalType": "Local"
+            }
+          ]
+        },
+        {
+          "name": "result",
+          "type": "tuple",
+          "internalType": "struct MgvLib.OrderResult",
+          "components": [
+            {
+              "name": "makerData",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "mgvData",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "noRouter",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct Direct.RouterParams",
+          "components": [
+            {
+              "name": "routerImplementation",
+              "type": "address",
+              "internalType": "contract AbstractRouter"
+            },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "strict",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "pure"
+    },
+    {
+      "type": "function",
+      "name": "offerIdOfIndex",
+      "inputs": [
+        {
+          "name": "ba",
+          "type": "uint8",
+          "internalType": "enum OfferType"
+        },
+        {
+          "name": "index",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "offeredVolume",
+      "inputs": [
+        {
+          "name": "ba",
+          "type": "uint8",
+          "internalType": "enum OfferType"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "volume",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "params",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "gasprice",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "gasreq",
+          "type": "uint24",
+          "internalType": "uint24"
+        },
+        {
+          "name": "stepSize",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "pricePoints",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "pending",
+      "inputs": [
+        {
+          "name": "ba",
+          "type": "uint8",
+          "internalType": "enum OfferType"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "int256",
+          "internalType": "int256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "populate",
+      "inputs": [
+        {
+          "name": "distribution",
+          "type": "tuple",
+          "internalType": "struct DirectWithBidsAndAsksDistribution.Distribution",
+          "components": [
+            {
+              "name": "asks",
+              "type": "tuple[]",
+              "internalType": "struct DirectWithBidsAndAsksDistribution.DistributionOffer[]",
+              "components": [
+                {
+                  "name": "index",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "tick",
+                  "type": "int256",
+                  "internalType": "Tick"
+                },
+                {
+                  "name": "gives",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "bids",
+              "type": "tuple[]",
+              "internalType": "struct DirectWithBidsAndAsksDistribution.DistributionOffer[]",
+              "components": [
+                {
+                  "name": "index",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "tick",
+                  "type": "int256",
+                  "internalType": "Tick"
+                },
+                {
+                  "name": "gives",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "parameters",
+          "type": "tuple",
+          "internalType": "struct CoreKandel.Params",
+          "components": [
+            {
+              "name": "gasprice",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "gasreq",
+              "type": "uint24",
+              "internalType": "uint24"
+            },
+            {
+              "name": "stepSize",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "pricePoints",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ]
+        },
+        {
+          "name": "baseAmount",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "quoteAmount",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "populateChunk",
+      "inputs": [
+        {
+          "name": "distribution",
+          "type": "tuple",
+          "internalType": "struct DirectWithBidsAndAsksDistribution.Distribution",
+          "components": [
+            {
+              "name": "asks",
+              "type": "tuple[]",
+              "internalType": "struct DirectWithBidsAndAsksDistribution.DistributionOffer[]",
+              "components": [
+                {
+                  "name": "index",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "tick",
+                  "type": "int256",
+                  "internalType": "Tick"
+                },
+                {
+                  "name": "gives",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "bids",
+              "type": "tuple[]",
+              "internalType": "struct DirectWithBidsAndAsksDistribution.DistributionOffer[]",
+              "components": [
+                {
+                  "name": "index",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "tick",
+                  "type": "int256",
+                  "internalType": "Tick"
+                },
+                {
+                  "name": "gives",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "populateChunkFromOffset",
+      "inputs": [
+        {
+          "name": "from",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "to",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "baseQuoteTickIndex0",
+          "type": "int256",
+          "internalType": "Tick"
+        },
+        {
+          "name": "firstAskIndex",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "bidGives",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "askGives",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "populateFromOffset",
+      "inputs": [
+        {
+          "name": "from",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "to",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "baseQuoteTickIndex0",
+          "type": "int256",
+          "internalType": "Tick"
+        },
+        {
+          "name": "_baseQuoteTickOffset",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "firstAskIndex",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "bidGives",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "askGives",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "parameters",
+          "type": "tuple",
+          "internalType": "struct CoreKandel.Params",
+          "components": [
+            {
+              "name": "gasprice",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "gasreq",
+              "type": "uint24",
+              "internalType": "uint24"
+            },
+            {
+              "name": "stepSize",
+              "type": "uint32",
+              "internalType": "uint32"
+            },
+            {
+              "name": "pricePoints",
+              "type": "uint32",
+              "internalType": "uint32"
+            }
+          ]
+        },
+        {
+          "name": "baseAmount",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "quoteAmount",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "provisionOf",
+      "inputs": [
+        {
+          "name": "olKey",
+          "type": "tuple",
+          "internalType": "struct OLKey",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "provision",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "reserveBalance",
+      "inputs": [
+        {
+          "name": "ba",
+          "type": "uint8",
+          "internalType": "enum OfferType"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "balance",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "retractAndWithdraw",
+      "inputs": [
+        {
+          "name": "from",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "to",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "baseAmount",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "quoteAmount",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "freeWei",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "recipient",
+          "type": "address",
+          "internalType": "address payable"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "retractOffers",
+      "inputs": [
+        {
+          "name": "from",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "to",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "router",
+      "inputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "router",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "setAdmin",
+      "inputs": [
+        {
+          "name": "admin_",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setBaseQuoteTickOffset",
+      "inputs": [
+        {
+          "name": "_baseQuoteTickOffset",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setGasprice",
+      "inputs": [
+        {
+          "name": "gasprice",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setGasreq",
+      "inputs": [
+        {
+          "name": "gasreq",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setStepSize",
+      "inputs": [
+        {
+          "name": "stepSize",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "withdrawFromMangrove",
+      "inputs": [
+        {
+          "name": "amount",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "receiver",
+          "type": "address",
+          "internalType": "address payable"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "withdrawFunds",
+      "inputs": [
+        {
+          "name": "baseAmount",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "quoteAmount",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "recipient",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "Credit",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "indexed": true,
+          "internalType": "contract IERC20"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Debit",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "indexed": true,
+          "internalType": "contract IERC20"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "LogIncident",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "makerData",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "mgvData",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OfferListKey",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PopulateEnd",
+      "inputs": [],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "PopulateStart",
+      "inputs": [],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RetractEnd",
+      "inputs": [],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RetractStart",
+      "inputs": [],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetAdmin",
+      "inputs": [
+        {
+          "name": "admin",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetBaseQuoteTickOffset",
+      "inputs": [
+        {
+          "name": "value",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetGasprice",
+      "inputs": [
+        {
+          "name": "value",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetGasreq",
+      "inputs": [
+        {
+          "name": "value",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetIndexMapping",
+      "inputs": [
+        {
+          "name": "ba",
+          "type": "uint8",
+          "indexed": true,
+          "internalType": "enum OfferType"
+        },
+        {
+          "name": "index",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetLength",
+      "inputs": [
+        {
+          "name": "value",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetStepSize",
+      "inputs": [
+        {
+          "name": "value",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    }
+  ]
+}

--- a/src/assets/strats/v2.0.1-0/KandelSeeder.json
+++ b/src/assets/strats/v2.0.1-0/KandelSeeder.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "../../../../contract.schema.json",
+  "released": false,
+  "contractName": "KandelSeeder",
+  "version": "2.0.1-0",
+  "networkAddresses": {
+    "168587773": {
+      "primaryAddress": "0x1A839030107167452D69d8f1a673004B2a1b8A3A",
+      "allAddresses": [
+        {
+          "address": "0x1A839030107167452D69d8f1a673004B2a1b8A3A",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x579ba1708e8E15c9D41143a3da4B8382831E0897"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "mgv",
+          "type": "address",
+          "internalType": "contract IMangrove"
+        },
+        {
+          "name": "kandelGasreq",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "KANDEL_GASREQ",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "MGV",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract IMangrove"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "sow",
+      "inputs": [
+        {
+          "name": "olKeyBaseQuote",
+          "type": "tuple",
+          "internalType": "struct OLKey",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "name": "liquiditySharing",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "kandel",
+          "type": "address",
+          "internalType": "contract GeometricKandel"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "NewKandel",
+      "inputs": [
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "baseQuoteOlKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "quoteBaseOlKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "kandel",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    }
+  ]
+}

--- a/src/assets/strats/v2.1.0-0/BlastMangroveAmplifier.json
+++ b/src/assets/strats/v2.1.0-0/BlastMangroveAmplifier.json
@@ -1,0 +1,710 @@
+{
+  "$schema": "../../../../contract.schema.json",
+  "released": false,
+  "contractName": "BlastMangroveAmplifier",
+  "deploymentName": "MangroveAmplifier",
+  "version": "2.1.0-0",
+  "networkAddresses": {
+    "168587773": {
+      "primaryAddress": "0xCbB118083D78f424b73602E05c141313215b732d",
+      "allAddresses": [
+        {
+          "address": "0xCbB118083D78f424b73602E05c141313215b732d",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x579ba1708e8E15c9D41143a3da4B8382831E0897"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "mgv",
+          "type": "address",
+          "internalType": "contract IMangrove"
+        },
+        {
+          "name": "factory",
+          "type": "address",
+          "internalType": "contract RouterProxyFactory"
+        },
+        {
+          "name": "routerImplementation",
+          "type": "address",
+          "internalType": "contract BlastSmartRouter"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    { "type": "receive", "stateMutability": "payable" },
+    {
+      "type": "function",
+      "name": "MGV",
+      "inputs": [],
+      "outputs": [
+        { "name": "", "type": "address", "internalType": "contract IMangrove" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROUTER_FACTORY",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract RouterProxyFactory"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROUTER_IMPLEMENTATION",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "activate",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "admin",
+      "inputs": [],
+      "outputs": [
+        { "name": "current", "type": "address", "internalType": "address" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "approve",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        { "name": "spender", "type": "address", "internalType": "address" },
+        { "name": "amount", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "blastPointsAdmin",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "makerExecute",
+      "inputs": [
+        {
+          "name": "order",
+          "type": "tuple",
+          "internalType": "struct MgvLib.SingleOrder",
+          "components": [
+            {
+              "name": "olKey",
+              "type": "tuple",
+              "internalType": "struct OLKey",
+              "components": [
+                {
+                  "name": "outbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "inbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "tickSpacing",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            { "name": "offer", "type": "uint256", "internalType": "Offer" },
+            {
+              "name": "takerWants",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "takerGives",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "offerDetail",
+              "type": "uint256",
+              "internalType": "OfferDetail"
+            },
+            { "name": "global", "type": "uint256", "internalType": "Global" },
+            { "name": "local", "type": "uint256", "internalType": "Local" }
+          ]
+        }
+      ],
+      "outputs": [
+        { "name": "ret", "type": "bytes32", "internalType": "bytes32" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "makerPosthook",
+      "inputs": [
+        {
+          "name": "order",
+          "type": "tuple",
+          "internalType": "struct MgvLib.SingleOrder",
+          "components": [
+            {
+              "name": "olKey",
+              "type": "tuple",
+              "internalType": "struct OLKey",
+              "components": [
+                {
+                  "name": "outbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "inbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "tickSpacing",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            { "name": "offer", "type": "uint256", "internalType": "Offer" },
+            {
+              "name": "takerWants",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "takerGives",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "offerDetail",
+              "type": "uint256",
+              "internalType": "OfferDetail"
+            },
+            { "name": "global", "type": "uint256", "internalType": "Global" },
+            { "name": "local", "type": "uint256", "internalType": "Local" }
+          ]
+        },
+        {
+          "name": "result",
+          "type": "tuple",
+          "internalType": "struct MgvLib.OrderResult",
+          "components": [
+            {
+              "name": "makerData",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            { "name": "mgvData", "type": "bytes32", "internalType": "bytes32" }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "newBundle",
+      "inputs": [
+        {
+          "name": "fx",
+          "type": "tuple",
+          "internalType": "struct MangroveAmplifier.FixedBundleParams",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "outVolume",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "outboundLogic",
+              "type": "address",
+              "internalType": "contract AbstractRoutingLogic"
+            },
+            {
+              "name": "expiryDate",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "name": "vr",
+          "type": "tuple[]",
+          "internalType": "struct MangroveAmplifier.VariableBundleParams[]",
+          "components": [
+            { "name": "tick", "type": "int256", "internalType": "Tick" },
+            { "name": "gasreq", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "provision",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "inboundLogic",
+              "type": "address",
+              "internalType": "contract AbstractRoutingLogic"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "contract IERC20"
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "freshBundleId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "offersOf",
+      "inputs": [
+        { "name": "bundleId", "type": "uint256", "internalType": "uint256" },
+        {
+          "name": "outbound_tkn",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct MangroveAmplifier.BundledOffer[]",
+          "components": [
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ownerOf",
+      "inputs": [
+        { "name": "bundleId", "type": "uint256", "internalType": "uint256" },
+        {
+          "name": "outbound_tkn",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ownerOf",
+      "inputs": [
+        { "name": "olKeyHash", "type": "bytes32", "internalType": "bytes32" },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [
+        { "name": "owner", "type": "address", "internalType": "address" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "provisionOf",
+      "inputs": [
+        {
+          "name": "olKey",
+          "type": "tuple",
+          "internalType": "struct OLKey",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [
+        { "name": "provision", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "reneging",
+      "inputs": [
+        { "name": "olKeyHash", "type": "bytes32", "internalType": "bytes32" },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct RenegingForwarder.Condition",
+          "components": [
+            { "name": "date", "type": "uint160", "internalType": "uint160" },
+            { "name": "volume", "type": "uint96", "internalType": "uint96" }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "retractBundle",
+      "inputs": [
+        { "name": "bundleId", "type": "uint256", "internalType": "uint256" },
+        {
+          "name": "outbound_tkn",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [
+        { "name": "freeWei", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "retractOffer",
+      "inputs": [
+        {
+          "name": "olKey",
+          "type": "tuple",
+          "internalType": "struct OLKey",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+        { "name": "deprovision", "type": "bool", "internalType": "bool" }
+      ],
+      "outputs": [
+        { "name": "freeWei", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "router",
+      "inputs": [
+        { "name": "fundOwner", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "setAdmin",
+      "inputs": [
+        { "name": "admin_", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setReneging",
+      "inputs": [
+        { "name": "olKeyHash", "type": "bytes32", "internalType": "bytes32" },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+        { "name": "expiryDate", "type": "uint256", "internalType": "uint256" },
+        { "name": "volume", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "updateBundle",
+      "inputs": [
+        { "name": "bundleId", "type": "uint256", "internalType": "uint256" },
+        {
+          "name": "outbound_tkn",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        {
+          "name": "outboundVolume",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        { "name": "updateExpiry", "type": "bool", "internalType": "bool" },
+        { "name": "expiryDate", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "updateOffer",
+      "inputs": [
+        {
+          "name": "olKey",
+          "type": "tuple",
+          "internalType": "struct OLKey",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        { "name": "tick", "type": "int256", "internalType": "Tick" },
+        { "name": "gives", "type": "uint256", "internalType": "uint256" },
+        { "name": "gasreq", "type": "uint256", "internalType": "uint256" },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "withdrawFromMangrove",
+      "inputs": [
+        { "name": "amount", "type": "uint256", "internalType": "uint256" },
+        {
+          "name": "receiver",
+          "type": "address",
+          "internalType": "address payable"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    { "type": "event", "name": "EndBundle", "inputs": [], "anonymous": false },
+    {
+      "type": "event",
+      "name": "InitBundle",
+      "inputs": [
+        {
+          "name": "bundleId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "outbound_tkn",
+          "type": "address",
+          "indexed": true,
+          "internalType": "contract IERC20"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "LogIncident",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "makerData",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "mgvData",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "NewOwnedOffer",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetAdmin",
+      "inputs": [
+        {
+          "name": "admin",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetReneging",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "date",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "volume",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    }
+  ]
+}

--- a/src/assets/strats/v2.1.0-0/BlastMangroveOrder-Router.json
+++ b/src/assets/strats/v2.1.0-0/BlastMangroveOrder-Router.json
@@ -1,0 +1,377 @@
+{
+  "$schema": "../../../../contract.schema.json",
+  "released": false,
+  "contractName": "BlastSmartRouter",
+  "deploymentName": "MangroveOrder-Router",
+  "version": "2.1.0-0",
+  "networkAddresses": {
+    "168587773": {
+      "primaryAddress": "0x95cD81c84423D65dEc3AAeA31D55C61E4310D21C",
+      "allAddresses": [
+        {
+          "address": "0x95cD81c84423D65dEc3AAeA31D55C61E4310D21C",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x579ba1708e8E15c9D41143a3da4B8382831E0897"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "_forcedBinding",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "admin",
+      "inputs": [],
+      "outputs": [
+        { "name": "current", "type": "address", "internalType": "address" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "bind",
+      "inputs": [
+        {
+          "name": "makerContract",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "flush",
+      "inputs": [
+        {
+          "name": "routingOrders",
+          "type": "tuple[]",
+          "internalType": "struct RoutingOrderLib.RoutingOrder[]",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "forcedBinding",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getLogic",
+      "inputs": [
+        {
+          "name": "routingOrder",
+          "type": "tuple",
+          "internalType": "struct RoutingOrderLib.RoutingOrder",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract AbstractRoutingLogic"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "isBound",
+      "inputs": [
+        { "name": "mkr", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "pull",
+      "inputs": [
+        {
+          "name": "routingOrder",
+          "type": "tuple",
+          "internalType": "struct RoutingOrderLib.RoutingOrder",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        { "name": "amount", "type": "uint256", "internalType": "uint256" },
+        { "name": "strict", "type": "bool", "internalType": "bool" }
+      ],
+      "outputs": [
+        { "name": "pulled", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "push",
+      "inputs": [
+        {
+          "name": "routingOrder",
+          "type": "tuple",
+          "internalType": "struct RoutingOrderLib.RoutingOrder",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        { "name": "amount", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [
+        { "name": "pushed", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setAdmin",
+      "inputs": [
+        { "name": "admin_", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setLogic",
+      "inputs": [
+        {
+          "name": "routingOrder",
+          "type": "tuple",
+          "internalType": "struct RoutingOrderLib.RoutingOrder",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "name": "logic",
+          "type": "address",
+          "internalType": "contract AbstractRoutingLogic"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "tokenBalanceOf",
+      "inputs": [
+        {
+          "name": "routingOrder",
+          "type": "tuple",
+          "internalType": "struct RoutingOrderLib.RoutingOrder",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "unbind",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "unbind",
+      "inputs": [
+        {
+          "name": "makerContract",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "MakerBind",
+      "inputs": [
+        {
+          "name": "maker",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MakerUnbind",
+      "inputs": [
+        {
+          "name": "maker",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetAdmin",
+      "inputs": [
+        {
+          "name": "admin",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetRouteLogic",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "indexed": true,
+          "internalType": "contract IERC20"
+        },
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "logic",
+          "type": "address",
+          "indexed": false,
+          "internalType": "contract AbstractRoutingLogic"
+        }
+      ],
+      "anonymous": false
+    }
+  ]
+}

--- a/src/assets/strats/v2.1.0-0/BlastMangroveOrder.json
+++ b/src/assets/strats/v2.1.0-0/BlastMangroveOrder.json
@@ -1,0 +1,695 @@
+{
+  "$schema": "../../../../contract.schema.json",
+  "released": false,
+  "contractName": "BlastMangroveOrder",
+  "deploymentName": "MangroveOrder",
+  "version": "2.1.0-0",
+  "networkAddresses": {
+    "168587773": {
+      "primaryAddress": "0x710cE7BB7eC4c4e76C716A9c0F8Ba8Fe55445460",
+      "allAddresses": [
+        {
+          "address": "0x710cE7BB7eC4c4e76C716A9c0F8Ba8Fe55445460",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x579ba1708e8E15c9D41143a3da4B8382831E0897"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "mgv",
+          "type": "address",
+          "internalType": "contract IMangrove"
+        },
+        {
+          "name": "factory",
+          "type": "address",
+          "internalType": "contract RouterProxyFactory"
+        },
+        { "name": "deployer", "type": "address", "internalType": "address" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    { "type": "receive", "stateMutability": "payable" },
+    {
+      "type": "function",
+      "name": "MGV",
+      "inputs": [],
+      "outputs": [
+        { "name": "", "type": "address", "internalType": "contract IMangrove" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROUTER_FACTORY",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract RouterProxyFactory"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROUTER_IMPLEMENTATION",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "activate",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "admin",
+      "inputs": [],
+      "outputs": [
+        { "name": "current", "type": "address", "internalType": "address" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "approve",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        { "name": "spender", "type": "address", "internalType": "address" },
+        { "name": "amount", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "blastPointsAdmin",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "makerExecute",
+      "inputs": [
+        {
+          "name": "order",
+          "type": "tuple",
+          "internalType": "struct MgvLib.SingleOrder",
+          "components": [
+            {
+              "name": "olKey",
+              "type": "tuple",
+              "internalType": "struct OLKey",
+              "components": [
+                {
+                  "name": "outbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "inbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "tickSpacing",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            { "name": "offer", "type": "uint256", "internalType": "Offer" },
+            {
+              "name": "takerWants",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "takerGives",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "offerDetail",
+              "type": "uint256",
+              "internalType": "OfferDetail"
+            },
+            { "name": "global", "type": "uint256", "internalType": "Global" },
+            { "name": "local", "type": "uint256", "internalType": "Local" }
+          ]
+        }
+      ],
+      "outputs": [
+        { "name": "ret", "type": "bytes32", "internalType": "bytes32" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "makerPosthook",
+      "inputs": [
+        {
+          "name": "order",
+          "type": "tuple",
+          "internalType": "struct MgvLib.SingleOrder",
+          "components": [
+            {
+              "name": "olKey",
+              "type": "tuple",
+              "internalType": "struct OLKey",
+              "components": [
+                {
+                  "name": "outbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "inbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "tickSpacing",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            { "name": "offer", "type": "uint256", "internalType": "Offer" },
+            {
+              "name": "takerWants",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "takerGives",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "offerDetail",
+              "type": "uint256",
+              "internalType": "OfferDetail"
+            },
+            { "name": "global", "type": "uint256", "internalType": "Global" },
+            { "name": "local", "type": "uint256", "internalType": "Local" }
+          ]
+        },
+        {
+          "name": "result",
+          "type": "tuple",
+          "internalType": "struct MgvLib.OrderResult",
+          "components": [
+            {
+              "name": "makerData",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            { "name": "mgvData", "type": "bytes32", "internalType": "bytes32" }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "ownerOf",
+      "inputs": [
+        { "name": "olKeyHash", "type": "bytes32", "internalType": "bytes32" },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [
+        { "name": "owner", "type": "address", "internalType": "address" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "provisionOf",
+      "inputs": [
+        {
+          "name": "olKey",
+          "type": "tuple",
+          "internalType": "struct OLKey",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [
+        { "name": "provision", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "reneging",
+      "inputs": [
+        { "name": "olKeyHash", "type": "bytes32", "internalType": "bytes32" },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct RenegingForwarder.Condition",
+          "components": [
+            { "name": "date", "type": "uint160", "internalType": "uint160" },
+            { "name": "volume", "type": "uint96", "internalType": "uint96" }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "retractOffer",
+      "inputs": [
+        {
+          "name": "olKey",
+          "type": "tuple",
+          "internalType": "struct OLKey",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+        { "name": "deprovision", "type": "bool", "internalType": "bool" }
+      ],
+      "outputs": [
+        { "name": "freeWei", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "router",
+      "inputs": [
+        { "name": "fundOwner", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "setAdmin",
+      "inputs": [
+        { "name": "admin_", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setReneging",
+      "inputs": [
+        { "name": "olKeyHash", "type": "bytes32", "internalType": "bytes32" },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+        { "name": "expiryDate", "type": "uint256", "internalType": "uint256" },
+        { "name": "volume", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "take",
+      "inputs": [
+        {
+          "name": "tko",
+          "type": "tuple",
+          "internalType": "struct IOrderLogic.TakerOrder",
+          "components": [
+            {
+              "name": "olKey",
+              "type": "tuple",
+              "internalType": "struct OLKey",
+              "components": [
+                {
+                  "name": "outbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "inbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "tickSpacing",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            { "name": "tick", "type": "int256", "internalType": "Tick" },
+            {
+              "name": "orderType",
+              "type": "uint8",
+              "internalType": "enum TakerOrderType"
+            },
+            {
+              "name": "fillVolume",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            { "name": "fillWants", "type": "bool", "internalType": "bool" },
+            {
+              "name": "expiryDate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "restingOrderGasreq",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "takerGivesLogic",
+              "type": "address",
+              "internalType": "contract AbstractRoutingLogic"
+            },
+            {
+              "name": "takerWantsLogic",
+              "type": "address",
+              "internalType": "contract AbstractRoutingLogic"
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "res",
+          "type": "tuple",
+          "internalType": "struct IOrderLogic.TakerOrderResult",
+          "components": [
+            {
+              "name": "takerGot",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "takerGave",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            { "name": "bounty", "type": "uint256", "internalType": "uint256" },
+            { "name": "fee", "type": "uint256", "internalType": "uint256" },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "offerWriteData",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "updateOffer",
+      "inputs": [
+        {
+          "name": "olKey",
+          "type": "tuple",
+          "internalType": "struct OLKey",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        { "name": "tick", "type": "int256", "internalType": "Tick" },
+        { "name": "gives", "type": "uint256", "internalType": "uint256" },
+        { "name": "gasreq", "type": "uint256", "internalType": "uint256" },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "withdrawFromMangrove",
+      "inputs": [
+        { "name": "amount", "type": "uint256", "internalType": "uint256" },
+        {
+          "name": "receiver",
+          "type": "address",
+          "internalType": "address payable"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "LogIncident",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "makerData",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "mgvData",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MangroveOrderComplete",
+      "inputs": [],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MangroveOrderStart",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "taker",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "tick",
+          "type": "int256",
+          "indexed": false,
+          "internalType": "Tick"
+        },
+        {
+          "name": "orderType",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum TakerOrderType"
+        },
+        {
+          "name": "fillVolume",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "fillWants",
+          "type": "bool",
+          "indexed": false,
+          "internalType": "bool"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "takerGivesLogic",
+          "type": "address",
+          "indexed": false,
+          "internalType": "contract AbstractRoutingLogic"
+        },
+        {
+          "name": "takerWantsLogic",
+          "type": "address",
+          "indexed": false,
+          "internalType": "contract AbstractRoutingLogic"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "NewOwnedOffer",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetAdmin",
+      "inputs": [
+        {
+          "name": "admin",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetReneging",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "date",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "volume",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    }
+  ]
+}

--- a/src/assets/strats/v2.1.0-0/BlastRouterProxyFactory.json
+++ b/src/assets/strats/v2.1.0-0/BlastRouterProxyFactory.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "../../../../contract.schema.json",
+  "released": false,
+  "contractName": "BlastRouterProxyFactory",
+  "deploymentName": "RouterProxyFactory",
+  "version": "2.1.0-0",
+  "networkAddresses": {
+    "168587773": {
+      "primaryAddress": "0x77CD6977011658019B8aF1b77C6b1310dFA35508",
+      "allAddresses": [
+        {
+          "address": "0x77CD6977011658019B8aF1b77C6b1310dFA35508",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x579ba1708e8E15c9D41143a3da4B8382831E0897"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        { "name": "_admin", "type": "address", "internalType": "address" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "admin",
+      "inputs": [],
+      "outputs": [
+        { "name": "current", "type": "address", "internalType": "address" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "blastPointsAdmin",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "computeProxyAddress",
+      "inputs": [
+        { "name": "owner", "type": "address", "internalType": "address" },
+        {
+          "name": "routerImplementation",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "outputs": [
+        { "name": "", "type": "address", "internalType": "address payable" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "deployProxy",
+      "inputs": [
+        { "name": "owner", "type": "address", "internalType": "address" },
+        {
+          "name": "routerImplementation",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "proxy",
+          "type": "address",
+          "internalType": "contract RouterProxy"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "instantiate",
+      "inputs": [
+        { "name": "owner", "type": "address", "internalType": "address" },
+        {
+          "name": "routerImplementation",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "proxy",
+          "type": "address",
+          "internalType": "contract RouterProxy"
+        },
+        { "name": "created", "type": "bool", "internalType": "bool" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setAdmin",
+      "inputs": [
+        { "name": "admin_", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "ProxyDeployed",
+      "inputs": [
+        {
+          "name": "proxy",
+          "type": "address",
+          "indexed": false,
+          "internalType": "contract RouterProxy"
+        },
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "implementation",
+          "type": "address",
+          "indexed": true,
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetAdmin",
+      "inputs": [
+        {
+          "name": "admin",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    }
+  ]
+}

--- a/src/strats.ts
+++ b/src/strats.ts
@@ -300,6 +300,9 @@ export const getLatestStratContractsPerNetwork = (
   filter?: DeploymentFilter,
   mangroveFilter?: DeploymentFilter,
 ): Record<string, StratContractsNetworkDeployment> => {
+  if (mangroveFilter === undefined && filter !== undefined) {
+    mangroveFilter = { released: filter.released };
+  }
   const latestMangrovePerNetwork = getLatestMangrovePerNetwork(mangroveFilter);
   const latestStratContractsPerNetwork: Record<
     string,

--- a/src/strats.ts
+++ b/src/strats.ts
@@ -15,6 +15,14 @@ import MangroveOrder_v2_0_0_b1_0 from "./assets/strats/v2.0.0-b1.0/MangroveOrder
 import RouterProxyFactory_v2_0_0_b1_0 from "./assets/strats/v2.0.0-b1.0/RouterProxyFactory.json";
 import SimpleAaveLogic_v2_0_0_b1_0 from "./assets/strats/v2.0.0-b1.0/SimpleAaveLogic.json";
 import MangroveAmplifier_v2_0_0_b1_0 from "./assets/strats/v2.0.0-b1.0/MangroveAmplifier.json";
+// v2.0.1-0
+import KandelLib_v2_0_1_0 from "./assets/strats/v2.0.1-0/KandelLib.json";
+import KandelSeeder_v2_0_1_0 from "./assets/strats/v2.0.1-0/KandelSeeder.json";
+// v2.1.0-0
+import BlastMangroveAmplifier_v2_1_0_0 from "./assets/strats/v2.1.0-0/BlastMangroveAmplifier.json";
+import BlastMangroveOrderRouter_v2_1_0_0 from "./assets/strats/v2.1.0-0/BlastMangroveOrder-Router.json";
+import BlastMangroveOrder_v2_1_0_0 from "./assets/strats/v2.1.0-0/BlastMangroveOrder.json";
+import BlastRouterProxyFactory_v2_1_0_0 from "./assets/strats/v2.1.0-0/BlastRouterProxyFactory.json";
 
 import { getLatestMangrovePerNetwork } from "./core";
 
@@ -93,6 +101,7 @@ export const getLatestAavePooledRouterPerNetwork = (
 
 /** This is a sorted array (newest to oldest), exported for tests */
 export const _kandelLibDeployments: VersionDeployments[] = [
+  KandelLib_v2_0_1_0,
   KandelLib_v2_0_0_b1_0,
   KandelLib_v1_0_0,
 ];
@@ -122,6 +131,7 @@ export const getLatestKandelLibPerNetwork = (
 
 /** This is a sorted array (newest to oldest), exported for tests */
 export const _kandelSeederDeployments: VersionDeployments[] = [
+  KandelSeeder_v2_0_1_0,
   KandelSeeder_v2_0_0_b1_0,
   KandelSeeder_v1_0_0,
 ];
@@ -151,6 +161,7 @@ export const getLatestKandelSeederPerNetwork = (
 
 /** This is a sorted array (newest to oldest), exported for tests */
 export const _mangroveOrderRouterDeployments: VersionDeployments[] = [
+  BlastMangroveOrderRouter_v2_1_0_0,
   MangroveOrderRouter_v2_0_0_b1_0,
   MangroveOrderRouter_v1_0_0,
 ];
@@ -183,6 +194,7 @@ export const getLatestMangroveOrderRouterPerNetwork = (
 
 /** This is a sorted array (newest to oldest), exported for tests */
 export const _mangroveOrderDeployments: VersionDeployments[] = [
+  BlastMangroveOrder_v2_1_0_0,
   MangroveOrder_v2_0_0_b1_0,
   MangroveOrder_v1_0_0,
 ];
@@ -212,6 +224,7 @@ export const getLatestMangroveOrderPerNetwork = (
 
 /** This is a sorted array (newest to oldest), exported for tests */
 export const _routerProxyFactoryDeployments: VersionDeployments[] = [
+  BlastRouterProxyFactory_v2_1_0_0,
   RouterProxyFactory_v2_0_0_b1_0,
 ];
 
@@ -268,6 +281,7 @@ export const getLatestSimpleAaveLogicPerNetwork = (
 
 /** This is a sorted array (newest to oldest), exported for tests */
 export const _mangroveAmplifierDeployments: VersionDeployments[] = [
+  BlastMangroveAmplifier_v2_1_0_0,
   MangroveAmplifier_v2_0_0_b1_0,
 ];
 

--- a/test/unit/strats.unit.test.ts
+++ b/test/unit/strats.unit.test.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 import { describe, it } from "mocha";
 
 import Mangrove_v2_0_1 from "../../src/assets/core/v2.0.1/Mangrove.json";
+import BlastMangrove_v2_1_0_0 from "../../src/assets/core/v2.1.0-0/BlastMangrove.json";
 // v1.0.0
 import AaveKandelSeeder_v1_0_0 from "../../src/assets/strats/v1.0.0/AaveKandelSeeder.json";
 import AavePooledRouter_v1_0_0 from "../../src/assets/strats/v1.0.0/AavePooledRouter.json";
@@ -19,6 +20,14 @@ import MangroveOrder_v2_0_0_b1_0 from "../../src/assets/strats/v2.0.0-b1.0/Mangr
 import RouterProxyFactory_v2_0_0_b1_0 from "../../src/assets/strats/v2.0.0-b1.0/RouterProxyFactory.json";
 import SimpleAaveLogic_v2_0_0_b1_0 from "../../src/assets/strats/v2.0.0-b1.0/SimpleAaveLogic.json";
 import MangroveAmplifier_v2_0_0_b1_0 from "../../src/assets/strats/v2.0.0-b1.0/MangroveAmplifier.json";
+// v2.0.1-0
+import KandelLib_v2_0_1_0 from "../../src/assets/strats/v2.0.1-0/KandelLib.json";
+import KandelSeeder_v2_0_1_0 from "../../src/assets/strats/v2.0.1-0/KandelSeeder.json";
+// v2.1.0-0
+import BlastMangroveAmplifier_v2_1_0_0 from "../../src/assets/strats/v2.1.0-0/BlastMangroveAmplifier.json";
+import BlastMangroveOrderRouter_v2_1_0_0 from "../../src/assets/strats/v2.1.0-0/BlastMangroveOrder-Router.json";
+import BlastMangroveOrder_v2_1_0_0 from "../../src/assets/strats/v2.1.0-0/BlastMangroveOrder.json";
+import BlastRouterProxyFactory_v2_1_0_0 from "../../src/assets/strats/v2.1.0-0/BlastRouterProxyFactory.json";
 
 import {
   getAaveKandelSeederVersionDeployments,
@@ -138,9 +147,9 @@ describe("strats.ts", () => {
     describe("getKandelLibVersionDeployments", () => {
       it("should find the latest deployment first", () => {
         const result = getKandelLibVersionDeployments({ released: undefined });
-        assert.equal(result, KandelLib_v2_0_0_b1_0);
+        assert.equal(result, KandelLib_v2_0_1_0);
         // NB: Add older old versions here
-        [KandelLib_v1_0_0].forEach((version) => {
+        [KandelLib_v2_0_0_b1_0, KandelLib_v1_0_0].forEach((version) => {
           assert.notEqual(result, version);
         });
       });
@@ -152,6 +161,7 @@ describe("strats.ts", () => {
           getAllKandelLibVersionDeploymentsPerNetwork({ released: undefined }),
         ).to.deep.equal({
           "80001": [KandelLib_v2_0_0_b1_0, KandelLib_v1_0_0],
+          "168587773": [KandelLib_v2_0_1_0],
         });
       });
     });
@@ -165,6 +175,10 @@ describe("strats.ts", () => {
             KandelLib_v2_0_0_b1_0,
             "80001",
           ),
+          "168587773": firstVersionDeploymentsToVersionNetworkDeployment(
+            KandelLib_v2_0_1_0,
+            "168587773",
+          ),
         });
       });
     });
@@ -176,9 +190,9 @@ describe("strats.ts", () => {
         const result = getKandelSeederVersionDeployments({
           released: undefined,
         });
-        assert.equal(result, KandelSeeder_v2_0_0_b1_0);
+        assert.equal(result, KandelSeeder_v2_0_1_0);
         // NB: Add older old versions here
-        [KandelSeeder_v1_0_0].forEach((version) => {
+        [KandelSeeder_v2_0_0_b1_0, KandelSeeder_v1_0_0].forEach((version) => {
           assert.notEqual(result, version);
         });
       });
@@ -192,6 +206,7 @@ describe("strats.ts", () => {
           }),
         ).to.deep.equal({
           "80001": [KandelSeeder_v2_0_0_b1_0, KandelSeeder_v1_0_0],
+          "168587773": [KandelSeeder_v2_0_1_0],
         });
       });
     });
@@ -205,6 +220,10 @@ describe("strats.ts", () => {
             KandelSeeder_v2_0_0_b1_0,
             "80001",
           ),
+          "168587773": firstVersionDeploymentsToVersionNetworkDeployment(
+            KandelSeeder_v2_0_1_0,
+            "168587773",
+          ),
         });
       });
     });
@@ -216,11 +235,13 @@ describe("strats.ts", () => {
         const result = getMangroveOrderRouterVersionDeployments({
           released: undefined,
         });
-        assert.equal(result, MangroveOrderRouter_v2_0_0_b1_0);
+        assert.equal(result, BlastMangroveOrderRouter_v2_1_0_0);
         // NB: Add older old versions here
-        [MangroveOrderRouter_v1_0_0].forEach((version) => {
-          assert.notEqual(result, version);
-        });
+        [MangroveOrderRouter_v2_0_0_b1_0, MangroveOrderRouter_v1_0_0].forEach(
+          (version) => {
+            assert.notEqual(result, version);
+          },
+        );
       });
     });
 
@@ -235,6 +256,7 @@ describe("strats.ts", () => {
             MangroveOrderRouter_v2_0_0_b1_0,
             MangroveOrderRouter_v1_0_0,
           ],
+          "168587773": [BlastMangroveOrderRouter_v2_1_0_0],
         });
       });
     });
@@ -248,6 +270,10 @@ describe("strats.ts", () => {
             MangroveOrderRouter_v2_0_0_b1_0,
             "80001",
           ),
+          "168587773": firstVersionDeploymentsToVersionNetworkDeployment(
+            BlastMangroveOrderRouter_v2_1_0_0,
+            "168587773",
+          ),
         });
       });
     });
@@ -259,9 +285,9 @@ describe("strats.ts", () => {
         const result = getMangroveOrderVersionDeployments({
           released: undefined,
         });
-        assert.equal(result, MangroveOrder_v2_0_0_b1_0);
+        assert.equal(result, BlastMangroveOrder_v2_1_0_0);
         // NB: Add older old versions here
-        [MangroveOrder_v1_0_0].forEach((version) => {
+        [MangroveOrder_v2_0_0_b1_0, MangroveOrder_v1_0_0].forEach((version) => {
           assert.notEqual(result, version);
         });
       });
@@ -275,6 +301,7 @@ describe("strats.ts", () => {
           }),
         ).to.deep.equal({
           "80001": [MangroveOrder_v2_0_0_b1_0, MangroveOrder_v1_0_0],
+          "168587773": [BlastMangroveOrder_v2_1_0_0],
         });
       });
     });
@@ -288,6 +315,10 @@ describe("strats.ts", () => {
             MangroveOrder_v2_0_0_b1_0,
             "80001",
           ),
+          "168587773": firstVersionDeploymentsToVersionNetworkDeployment(
+            BlastMangroveOrder_v2_1_0_0,
+            "168587773",
+          ),
         });
       });
     });
@@ -299,9 +330,9 @@ describe("strats.ts", () => {
         const result = getRouterProxyFactoryVersionDeployments({
           released: undefined,
         });
-        assert.equal(result, RouterProxyFactory_v2_0_0_b1_0);
+        assert.equal(result, BlastRouterProxyFactory_v2_1_0_0);
         // NB: Add older old versions here
-        [].forEach((version) => {
+        [RouterProxyFactory_v2_0_0_b1_0].forEach((version) => {
           assert.notEqual(result, version);
         });
       });
@@ -315,6 +346,7 @@ describe("strats.ts", () => {
           }),
         ).to.deep.equal({
           "80001": [RouterProxyFactory_v2_0_0_b1_0],
+          "168587773": [BlastRouterProxyFactory_v2_1_0_0],
         });
       });
     });
@@ -327,6 +359,10 @@ describe("strats.ts", () => {
           "80001": firstVersionDeploymentsToVersionNetworkDeployment(
             RouterProxyFactory_v2_0_0_b1_0,
             "80001",
+          ),
+          "168587773": firstVersionDeploymentsToVersionNetworkDeployment(
+            BlastRouterProxyFactory_v2_1_0_0,
+            "168587773",
           ),
         });
       });
@@ -379,9 +415,9 @@ describe("strats.ts", () => {
         const result = getMangroveAmplifierVersionDeployments({
           released: undefined,
         });
-        assert.equal(result, MangroveAmplifier_v2_0_0_b1_0);
+        assert.equal(result, BlastMangroveAmplifier_v2_1_0_0);
         // NB: Add older old versions here
-        [].forEach((version) => {
+        [MangroveAmplifier_v2_0_0_b1_0].forEach((version) => {
           assert.notEqual(result, version);
         });
       });
@@ -395,6 +431,7 @@ describe("strats.ts", () => {
           }),
         ).to.deep.equal({
           "80001": [MangroveAmplifier_v2_0_0_b1_0],
+          "168587773": [BlastMangroveAmplifier_v2_1_0_0],
         });
       });
     });
@@ -407,6 +444,10 @@ describe("strats.ts", () => {
           "80001": firstVersionDeploymentsToVersionNetworkDeployment(
             MangroveAmplifier_v2_0_0_b1_0,
             "80001",
+          ),
+          "168587773": firstVersionDeploymentsToVersionNetworkDeployment(
+            BlastMangroveAmplifier_v2_1_0_0,
+            "168587773",
           ),
         });
       });
@@ -478,18 +519,37 @@ describe("strats.ts", () => {
         },
         "168587773": {
           mangrove: firstVersionDeploymentsToVersionNetworkDeployment(
-            Mangrove_v2_0_1,
+            BlastMangrove_v2_1_0_0,
             "168587773",
           ),
           aaveKandelSeeder: undefined,
           aavePooledRouter: undefined,
-          kandelLib: undefined,
-          kandelSeeder: undefined,
-          mangroveOrderRouter: undefined,
-          mangroveOrder: undefined,
-          routerProxyFactory: undefined,
+          kandelLib: firstVersionDeploymentsToVersionNetworkDeployment(
+            KandelLib_v2_0_1_0,
+            "168587773",
+          ),
+          kandelSeeder: firstVersionDeploymentsToVersionNetworkDeployment(
+            KandelSeeder_v2_0_1_0,
+            "168587773",
+          ),
+          mangroveOrderRouter:
+            firstVersionDeploymentsToVersionNetworkDeployment(
+              BlastMangroveOrderRouter_v2_1_0_0,
+              "168587773",
+            ),
+          mangroveOrder: firstVersionDeploymentsToVersionNetworkDeployment(
+            BlastMangroveOrder_v2_1_0_0,
+            "168587773",
+          ),
+          routerProxyFactory: firstVersionDeploymentsToVersionNetworkDeployment(
+            BlastRouterProxyFactory_v2_1_0_0,
+            "168587773",
+          ),
           simpleAaveLogic: undefined,
-          mangroveAmplifier: undefined,
+          mangroveAmplifier: firstVersionDeploymentsToVersionNetworkDeployment(
+            BlastMangroveAmplifier_v2_1_0_0,
+            "168587773",
+          ),
         },
       });
     });


### PR DESCRIPTION
NB: mangrove-strats v2.1.0-0 has not been published yet, but we plan to publish it once the `feat/blastSupport` branch has been merged and the deployments were made from that branch.