### PR TITLE
ops: Add Mumbai deployments of mangrove-strats v2.0.1-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add deployments of `BlastMangrove`, `MgvOracle`, and `MgvReader` v2.1.0-0 to Blast Sepolia
 - Add deployments of `KandelLib` and `KandelSeeder` v2.0.1-0 to Blast Sepolia
 - Add deployments of `BlastMangroveAmplifier`, `BlastMangroveOrder-Router.json`, `BlastMangroveOrder`, and `BlastRouterProxyFactory` v2.1.0-0 to Blast Sepolia
+- Add deployments of strat contracts v2.0.1-0 to Mumbai. Except for `MangroveAmplifier` these are identical to the v2.0.0-b1.0 deployments, as no code was changed in-between; We duplicate them, so we can later simplify and just delete the v2.0.0-b1.0 deployments.
 
 # 2.0.3-2
 

--- a/src/assets/strats/v2.0.1-0/AaveKandelSeeder.json
+++ b/src/assets/strats/v2.0.1-0/AaveKandelSeeder.json
@@ -1,32 +1,18 @@
 {
   "$schema": "../../../../contract.schema.json",
   "released": false,
-  "contractName": "KandelSeeder",
+  "contractName": "AaveKandelSeeder",
   "version": "2.0.1-0",
   "networkAddresses": {
     "80001": {
-      "primaryAddress": "0x878f8820cd99a96381074548a1B72d27A77fadA2",
+      "primaryAddress": "0x215A21620Ded0451F4867A5Ffa347351826233a4",
       "allAddresses": [
         {
-          "address": "0x878f8820cd99a96381074548a1B72d27A77fadA2",
+          "address": "0x215A21620Ded0451F4867A5Ffa347351826233a4",
           "dependencies": [
             {
               "name": "Mangrove",
               "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
-            }
-          ]
-        }
-      ]
-    },
-    "168587773": {
-      "primaryAddress": "0x1A839030107167452D69d8f1a673004B2a1b8A3A",
-      "allAddresses": [
-        {
-          "address": "0x1A839030107167452D69d8f1a673004B2a1b8A3A",
-          "dependencies": [
-            {
-              "name": "Mangrove",
-              "address": "0x579ba1708e8E15c9D41143a3da4B8382831E0897"
             }
           ]
         }
@@ -43,12 +29,30 @@
           "internalType": "contract IMangrove"
         },
         {
-          "name": "kandelGasreq",
+          "name": "addressesProvider",
+          "type": "address",
+          "internalType": "contract IPoolAddressesProvider"
+        },
+        {
+          "name": "aaveKandelGasreq",
           "type": "uint256",
           "internalType": "uint256"
         }
       ],
       "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "AAVE_ROUTER",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract AavePooledRouter"
+        }
+      ],
+      "stateMutability": "view"
     },
     {
       "type": "function",
@@ -119,7 +123,7 @@
     },
     {
       "type": "event",
-      "name": "NewKandel",
+      "name": "NewAaveKandel",
       "inputs": [
         {
           "name": "owner",
@@ -140,7 +144,13 @@
           "internalType": "bytes32"
         },
         {
-          "name": "kandel",
+          "name": "aaveKandel",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "reserveId",
           "type": "address",
           "indexed": false,
           "internalType": "address"

--- a/src/assets/strats/v2.0.1-0/AavePooledRouter.json
+++ b/src/assets/strats/v2.0.1-0/AavePooledRouter.json
@@ -1,0 +1,675 @@
+{
+  "$schema": "../../../../contract.schema.json",
+  "released": false,
+  "contractName": "AavePooledRouter",
+  "version": "2.0.1-0",
+  "networkAddresses": {
+    "80001": {
+      "primaryAddress": "0x111ad246979350ACCa951DFF283f15eb016059e1",
+      "allAddresses": [
+        {
+          "address": "0x111ad246979350ACCa951DFF283f15eb016059e1",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "addressesProvider",
+          "type": "address",
+          "internalType": "contract IPoolAddressesProvider"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "ADDRESS_PROVIDER",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract IPoolAddressesProvider"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "OFFSET",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "POOL",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract IPool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "aaveManager",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "admin",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "current",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "bind",
+      "inputs": [
+        {
+          "name": "makerContract",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "checkAsset",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "claimRewards",
+      "inputs": [
+        {
+          "name": "assets",
+          "type": "address[]",
+          "internalType": "address[]"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "rewardList",
+          "type": "address[]",
+          "internalType": "address[]"
+        },
+        {
+          "name": "claimedAmounts",
+          "type": "uint256[]",
+          "internalType": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "enterMarket",
+      "inputs": [
+        {
+          "name": "tokens",
+          "type": "address[]",
+          "internalType": "contract IERC20[]"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "exitMarket",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "flush",
+      "inputs": [
+        {
+          "name": "routingOrders",
+          "type": "tuple[]",
+          "internalType": "struct RoutingOrderLib.RoutingOrder[]",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "offerId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "flushBuffer",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        {
+          "name": "noRevert",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "reason",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "isBound",
+      "inputs": [
+        {
+          "name": "mkr",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "overlying",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "aToken",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "pull",
+      "inputs": [
+        {
+          "name": "routingOrder",
+          "type": "tuple",
+          "internalType": "struct RoutingOrderLib.RoutingOrder",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "offerId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "strict",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "pulled",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "push",
+      "inputs": [
+        {
+          "name": "routingOrder",
+          "type": "tuple",
+          "internalType": "struct RoutingOrderLib.RoutingOrder",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "offerId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "pushed",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "pushAndSupply",
+      "inputs": [
+        {
+          "name": "token0",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        {
+          "name": "amount0",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "token1",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        {
+          "name": "amount1",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "fundOwner",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "pushed0",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "pushed1",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setAaveManager",
+      "inputs": [
+        {
+          "name": "aaveManager_",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setAdmin",
+      "inputs": [
+        {
+          "name": "admin_",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "sharesOf",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        {
+          "name": "reserveId",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "shares",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "tokenBalanceOf",
+      "inputs": [
+        {
+          "name": "routingOrder",
+          "type": "tuple",
+          "internalType": "struct RoutingOrderLib.RoutingOrder",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "offerId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "totalBalance",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "balance",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "totalShares",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "total",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "unbind",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "unbind",
+      "inputs": [
+        {
+          "name": "makerContract",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "withdraw",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        {
+          "name": "reserveId",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "AaveIncident",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "indexed": true,
+          "internalType": "contract IERC20"
+        },
+        {
+          "name": "maker",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "reserveId",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "aaveReason",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MakerBind",
+      "inputs": [
+        {
+          "name": "maker",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MakerUnbind",
+      "inputs": [
+        {
+          "name": "maker",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetAaveManager",
+      "inputs": [
+        {
+          "name": "manager",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetAdmin",
+      "inputs": [
+        {
+          "name": "admin",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    }
+  ]
+}

--- a/src/assets/strats/v2.0.1-0/KandelLib.json
+++ b/src/assets/strats/v2.0.1-0/KandelLib.json
@@ -5,6 +5,20 @@
   "deploymentName": "KandelLib",
   "version": "2.0.1-0",
   "networkAddresses": {
+    "80001": {
+      "primaryAddress": "0xC383eeBF80B7372e7D5a761c7551D7B920D05bBD",
+      "allAddresses": [
+        {
+          "address": "0xC383eeBF80B7372e7D5a761c7551D7B920D05bBD",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+            }
+          ]
+        }
+      ]
+    },
     "168587773": {
       "primaryAddress": "0x00Bf28e29C398C168AAe0532373631fc41a2F77a",
       "allAddresses": [

--- a/src/assets/strats/v2.0.1-0/MangroveAmplifier.json
+++ b/src/assets/strats/v2.0.1-0/MangroveAmplifier.json
@@ -1,0 +1,899 @@
+{
+  "$schema": "../../../../contract.schema.json",
+  "released": false,
+  "contractName": "MangroveAmplifier",
+  "version": "2.0.1-0",
+  "networkAddresses": {
+    "80001": {
+      "primaryAddress": "0x5936A0CA18C72074852Ec81147B8D3FA714c423C",
+      "allAddresses": [
+        {
+          "address": "0x5936A0CA18C72074852Ec81147B8D3FA714c423C",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "mgv",
+          "type": "address",
+          "internalType": "contract IMangrove"
+        },
+        {
+          "name": "factory",
+          "type": "address",
+          "internalType": "contract RouterProxyFactory"
+        },
+        {
+          "name": "routerImplementation",
+          "type": "address",
+          "internalType": "contract SmartRouter"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "receive",
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "MGV",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract IMangrove"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROUTER_FACTORY",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract RouterProxyFactory"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROUTER_IMPLEMENTATION",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "activate",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "admin",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "current",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "approve",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        {
+          "name": "spender",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "makerExecute",
+      "inputs": [
+        {
+          "name": "order",
+          "type": "tuple",
+          "internalType": "struct MgvLib.SingleOrder",
+          "components": [
+            {
+              "name": "olKey",
+              "type": "tuple",
+              "internalType": "struct OLKey",
+              "components": [
+                {
+                  "name": "outbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "inbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "tickSpacing",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "offerId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "offer",
+              "type": "uint256",
+              "internalType": "Offer"
+            },
+            {
+              "name": "takerWants",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "takerGives",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "offerDetail",
+              "type": "uint256",
+              "internalType": "OfferDetail"
+            },
+            {
+              "name": "global",
+              "type": "uint256",
+              "internalType": "Global"
+            },
+            {
+              "name": "local",
+              "type": "uint256",
+              "internalType": "Local"
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "ret",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "makerPosthook",
+      "inputs": [
+        {
+          "name": "order",
+          "type": "tuple",
+          "internalType": "struct MgvLib.SingleOrder",
+          "components": [
+            {
+              "name": "olKey",
+              "type": "tuple",
+              "internalType": "struct OLKey",
+              "components": [
+                {
+                  "name": "outbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "inbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "tickSpacing",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "offerId",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "offer",
+              "type": "uint256",
+              "internalType": "Offer"
+            },
+            {
+              "name": "takerWants",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "takerGives",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "offerDetail",
+              "type": "uint256",
+              "internalType": "OfferDetail"
+            },
+            {
+              "name": "global",
+              "type": "uint256",
+              "internalType": "Global"
+            },
+            {
+              "name": "local",
+              "type": "uint256",
+              "internalType": "Local"
+            }
+          ]
+        },
+        {
+          "name": "result",
+          "type": "tuple",
+          "internalType": "struct MgvLib.OrderResult",
+          "components": [
+            {
+              "name": "makerData",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "mgvData",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "newBundle",
+      "inputs": [
+        {
+          "name": "fx",
+          "type": "tuple",
+          "internalType": "struct MangroveAmplifier.FixedBundleParams",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "outVolume",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "outboundLogic",
+              "type": "address",
+              "internalType": "contract AbstractRoutingLogic"
+            },
+            {
+              "name": "expiryDate",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "name": "vr",
+          "type": "tuple[]",
+          "internalType": "struct MangroveAmplifier.VariableBundleParams[]",
+          "components": [
+            {
+              "name": "tick",
+              "type": "int256",
+              "internalType": "Tick"
+            },
+            {
+              "name": "gasreq",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "provision",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "inboundLogic",
+              "type": "address",
+              "internalType": "contract AbstractRoutingLogic"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "contract IERC20"
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "freshBundleId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "offersOf",
+      "inputs": [
+        {
+          "name": "bundleId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct MangroveAmplifier.BundledOffer[]",
+          "components": [
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "offerId",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ownerOf",
+      "inputs": [
+        {
+          "name": "bundleId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "outbound_tkn",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ownerOf",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "owner",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "provisionOf",
+      "inputs": [
+        {
+          "name": "olKey",
+          "type": "tuple",
+          "internalType": "struct OLKey",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "provision",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "reneging",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct RenegingForwarder.Condition",
+          "components": [
+            {
+              "name": "date",
+              "type": "uint160",
+              "internalType": "uint160"
+            },
+            {
+              "name": "volume",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "retractBundle",
+      "inputs": [
+        {
+          "name": "bundleId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "outbound_tkn",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "freeWei",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "retractOffer",
+      "inputs": [
+        {
+          "name": "olKey",
+          "type": "tuple",
+          "internalType": "struct OLKey",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "deprovision",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "freeWei",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "router",
+      "inputs": [
+        {
+          "name": "fundOwner",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "setAdmin",
+      "inputs": [
+        {
+          "name": "admin_",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setReneging",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "expiryDate",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "volume",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "updateBundle",
+      "inputs": [
+        {
+          "name": "bundleId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "outbound_tkn",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        {
+          "name": "outboundVolume",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "updateExpiry",
+          "type": "bool",
+          "internalType": "bool"
+        },
+        {
+          "name": "expiryDate",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "updateOffer",
+      "inputs": [
+        {
+          "name": "olKey",
+          "type": "tuple",
+          "internalType": "struct OLKey",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "name": "tick",
+          "type": "int256",
+          "internalType": "Tick"
+        },
+        {
+          "name": "gives",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "gasreq",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "withdrawFromMangrove",
+      "inputs": [
+        {
+          "name": "amount",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "receiver",
+          "type": "address",
+          "internalType": "address payable"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "EndBundle",
+      "inputs": [],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "InitBundle",
+      "inputs": [
+        {
+          "name": "bundleId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "LogIncident",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "makerData",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "mgvData",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "NewOwnedOffer",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetAdmin",
+      "inputs": [
+        {
+          "name": "admin",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetReneging",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "date",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "volume",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    }
+  ]
+}

--- a/src/assets/strats/v2.0.1-0/MangroveOrder-Router.json
+++ b/src/assets/strats/v2.0.1-0/MangroveOrder-Router.json
@@ -1,0 +1,359 @@
+{
+  "$schema": "../../../../contract.schema.json",
+  "released": false,
+  "contractName": "SmartRouter",
+  "deploymentName": "MangroveOrder-Router",
+  "version": "2.0.1-0",
+  "networkAddresses": {
+    "80001": {
+      "primaryAddress": "0x16f320bb556CbA9D3E6f592765192F35eb64a78a",
+      "allAddresses": [
+        {
+          "address": "0x16f320bb556CbA9D3E6f592765192F35eb64a78a",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "abi": [
+    {
+      "type": "function",
+      "name": "admin",
+      "inputs": [],
+      "outputs": [
+        { "name": "current", "type": "address", "internalType": "address" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "bind",
+      "inputs": [
+        {
+          "name": "makerContract",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "flush",
+      "inputs": [
+        {
+          "name": "routingOrders",
+          "type": "tuple[]",
+          "internalType": "struct RoutingOrderLib.RoutingOrder[]",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "getLogic",
+      "inputs": [
+        {
+          "name": "routingOrder",
+          "type": "tuple",
+          "internalType": "struct RoutingOrderLib.RoutingOrder",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract AbstractRoutingLogic"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "isBound",
+      "inputs": [
+        { "name": "mkr", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "pull",
+      "inputs": [
+        {
+          "name": "routingOrder",
+          "type": "tuple",
+          "internalType": "struct RoutingOrderLib.RoutingOrder",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        { "name": "amount", "type": "uint256", "internalType": "uint256" },
+        { "name": "strict", "type": "bool", "internalType": "bool" }
+      ],
+      "outputs": [
+        { "name": "pulled", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "push",
+      "inputs": [
+        {
+          "name": "routingOrder",
+          "type": "tuple",
+          "internalType": "struct RoutingOrderLib.RoutingOrder",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        { "name": "amount", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [
+        { "name": "pushed", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setAdmin",
+      "inputs": [
+        { "name": "admin_", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setLogic",
+      "inputs": [
+        {
+          "name": "routingOrder",
+          "type": "tuple",
+          "internalType": "struct RoutingOrderLib.RoutingOrder",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        },
+        {
+          "name": "logic",
+          "type": "address",
+          "internalType": "contract AbstractRoutingLogic"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "tokenBalanceOf",
+      "inputs": [
+        {
+          "name": "routingOrder",
+          "type": "tuple",
+          "internalType": "struct RoutingOrderLib.RoutingOrder",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "contract IERC20"
+            },
+            {
+              "name": "olKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "fundOwner",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "unbind",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "unbind",
+      "inputs": [
+        {
+          "name": "makerContract",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "MakerBind",
+      "inputs": [
+        {
+          "name": "maker",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MakerUnbind",
+      "inputs": [
+        {
+          "name": "maker",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetAdmin",
+      "inputs": [
+        {
+          "name": "admin",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetRouteLogic",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "indexed": true,
+          "internalType": "contract IERC20"
+        },
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "logic",
+          "type": "address",
+          "indexed": false,
+          "internalType": "contract AbstractRoutingLogic"
+        }
+      ],
+      "anonymous": false
+    }
+  ]
+}

--- a/src/assets/strats/v2.0.1-0/MangroveOrder.json
+++ b/src/assets/strats/v2.0.1-0/MangroveOrder.json
@@ -1,0 +1,687 @@
+{
+  "$schema": "../../../../contract.schema.json",
+  "released": false,
+  "contractName": "MangroveOrder",
+  "version": "2.0.1-0",
+  "networkAddresses": {
+    "80001": {
+      "primaryAddress": "0x092FC43fe474030387BBa4C657F0ceBc1dC218E7",
+      "allAddresses": [
+        {
+          "address": "0x092FC43fe474030387BBa4C657F0ceBc1dC218E7",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "mgv",
+          "type": "address",
+          "internalType": "contract IMangrove"
+        },
+        {
+          "name": "factory",
+          "type": "address",
+          "internalType": "contract RouterProxyFactory"
+        },
+        { "name": "deployer", "type": "address", "internalType": "address" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    { "type": "receive", "stateMutability": "payable" },
+    {
+      "type": "function",
+      "name": "MGV",
+      "inputs": [],
+      "outputs": [
+        { "name": "", "type": "address", "internalType": "contract IMangrove" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROUTER_FACTORY",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract RouterProxyFactory"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROUTER_IMPLEMENTATION",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "activate",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "admin",
+      "inputs": [],
+      "outputs": [
+        { "name": "current", "type": "address", "internalType": "address" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "approve",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        { "name": "spender", "type": "address", "internalType": "address" },
+        { "name": "amount", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "makerExecute",
+      "inputs": [
+        {
+          "name": "order",
+          "type": "tuple",
+          "internalType": "struct MgvLib.SingleOrder",
+          "components": [
+            {
+              "name": "olKey",
+              "type": "tuple",
+              "internalType": "struct OLKey",
+              "components": [
+                {
+                  "name": "outbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "inbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "tickSpacing",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            { "name": "offer", "type": "uint256", "internalType": "Offer" },
+            {
+              "name": "takerWants",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "takerGives",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "offerDetail",
+              "type": "uint256",
+              "internalType": "OfferDetail"
+            },
+            { "name": "global", "type": "uint256", "internalType": "Global" },
+            { "name": "local", "type": "uint256", "internalType": "Local" }
+          ]
+        }
+      ],
+      "outputs": [
+        { "name": "ret", "type": "bytes32", "internalType": "bytes32" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "makerPosthook",
+      "inputs": [
+        {
+          "name": "order",
+          "type": "tuple",
+          "internalType": "struct MgvLib.SingleOrder",
+          "components": [
+            {
+              "name": "olKey",
+              "type": "tuple",
+              "internalType": "struct OLKey",
+              "components": [
+                {
+                  "name": "outbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "inbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "tickSpacing",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            { "name": "offer", "type": "uint256", "internalType": "Offer" },
+            {
+              "name": "takerWants",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "takerGives",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "offerDetail",
+              "type": "uint256",
+              "internalType": "OfferDetail"
+            },
+            { "name": "global", "type": "uint256", "internalType": "Global" },
+            { "name": "local", "type": "uint256", "internalType": "Local" }
+          ]
+        },
+        {
+          "name": "result",
+          "type": "tuple",
+          "internalType": "struct MgvLib.OrderResult",
+          "components": [
+            {
+              "name": "makerData",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            { "name": "mgvData", "type": "bytes32", "internalType": "bytes32" }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "ownerOf",
+      "inputs": [
+        { "name": "olKeyHash", "type": "bytes32", "internalType": "bytes32" },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [
+        { "name": "owner", "type": "address", "internalType": "address" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "provisionOf",
+      "inputs": [
+        {
+          "name": "olKey",
+          "type": "tuple",
+          "internalType": "struct OLKey",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [
+        { "name": "provision", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "reneging",
+      "inputs": [
+        { "name": "olKeyHash", "type": "bytes32", "internalType": "bytes32" },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct RenegingForwarder.Condition",
+          "components": [
+            { "name": "date", "type": "uint160", "internalType": "uint160" },
+            { "name": "volume", "type": "uint96", "internalType": "uint96" }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "retractOffer",
+      "inputs": [
+        {
+          "name": "olKey",
+          "type": "tuple",
+          "internalType": "struct OLKey",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+        { "name": "deprovision", "type": "bool", "internalType": "bool" }
+      ],
+      "outputs": [
+        { "name": "freeWei", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "router",
+      "inputs": [
+        { "name": "fundOwner", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "setAdmin",
+      "inputs": [
+        { "name": "admin_", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setReneging",
+      "inputs": [
+        { "name": "olKeyHash", "type": "bytes32", "internalType": "bytes32" },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+        { "name": "expiryDate", "type": "uint256", "internalType": "uint256" },
+        { "name": "volume", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "take",
+      "inputs": [
+        {
+          "name": "tko",
+          "type": "tuple",
+          "internalType": "struct IOrderLogic.TakerOrder",
+          "components": [
+            {
+              "name": "olKey",
+              "type": "tuple",
+              "internalType": "struct OLKey",
+              "components": [
+                {
+                  "name": "outbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "inbound_tkn",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "tickSpacing",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            { "name": "tick", "type": "int256", "internalType": "Tick" },
+            {
+              "name": "orderType",
+              "type": "uint8",
+              "internalType": "enum TakerOrderType"
+            },
+            {
+              "name": "fillVolume",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            { "name": "fillWants", "type": "bool", "internalType": "bool" },
+            {
+              "name": "expiryDate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "restingOrderGasreq",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "takerGivesLogic",
+              "type": "address",
+              "internalType": "contract AbstractRoutingLogic"
+            },
+            {
+              "name": "takerWantsLogic",
+              "type": "address",
+              "internalType": "contract AbstractRoutingLogic"
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "res",
+          "type": "tuple",
+          "internalType": "struct IOrderLogic.TakerOrderResult",
+          "components": [
+            {
+              "name": "takerGot",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "takerGave",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            { "name": "bounty", "type": "uint256", "internalType": "uint256" },
+            { "name": "fee", "type": "uint256", "internalType": "uint256" },
+            { "name": "offerId", "type": "uint256", "internalType": "uint256" },
+            {
+              "name": "offerWriteData",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "updateOffer",
+      "inputs": [
+        {
+          "name": "olKey",
+          "type": "tuple",
+          "internalType": "struct OLKey",
+          "components": [
+            {
+              "name": "outbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "inbound_tkn",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "tickSpacing",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        { "name": "tick", "type": "int256", "internalType": "Tick" },
+        { "name": "gives", "type": "uint256", "internalType": "uint256" },
+        { "name": "gasreq", "type": "uint256", "internalType": "uint256" },
+        { "name": "offerId", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "withdrawFromMangrove",
+      "inputs": [
+        { "name": "amount", "type": "uint256", "internalType": "uint256" },
+        {
+          "name": "receiver",
+          "type": "address",
+          "internalType": "address payable"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "LogIncident",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "makerData",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "mgvData",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MangroveOrderComplete",
+      "inputs": [],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "MangroveOrderStart",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "taker",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "tick",
+          "type": "int256",
+          "indexed": false,
+          "internalType": "Tick"
+        },
+        {
+          "name": "orderType",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "enum TakerOrderType"
+        },
+        {
+          "name": "fillVolume",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "fillWants",
+          "type": "bool",
+          "indexed": false,
+          "internalType": "bool"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "takerGivesLogic",
+          "type": "address",
+          "indexed": false,
+          "internalType": "contract AbstractRoutingLogic"
+        },
+        {
+          "name": "takerWantsLogic",
+          "type": "address",
+          "indexed": false,
+          "internalType": "contract AbstractRoutingLogic"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "NewOwnedOffer",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetAdmin",
+      "inputs": [
+        {
+          "name": "admin",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "SetReneging",
+      "inputs": [
+        {
+          "name": "olKeyHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "offerId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "date",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "volume",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    }
+  ]
+}

--- a/src/assets/strats/v2.0.1-0/RouterProxyFactory.json
+++ b/src/assets/strats/v2.0.1-0/RouterProxyFactory.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "../../../../contract.schema.json",
+  "released": false,
+  "contractName": "RouterProxyFactory",
+  "version": "2.0.1-0",
+  "networkAddresses": {
+    "80001": {
+      "primaryAddress": "0x2593BdD850EA25E87f3A1C83dcB8B49DAeddF0d1",
+      "allAddresses": [
+        {
+          "address": "0x2593BdD850EA25E87f3A1C83dcB8B49DAeddF0d1",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "abi": [
+    {
+      "type": "function",
+      "name": "computeProxyAddress",
+      "inputs": [
+        { "name": "owner", "type": "address", "internalType": "address" },
+        {
+          "name": "routerImplementation",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "outputs": [
+        { "name": "", "type": "address", "internalType": "address payable" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "deployProxy",
+      "inputs": [
+        { "name": "owner", "type": "address", "internalType": "address" },
+        {
+          "name": "routerImplementation",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "proxy",
+          "type": "address",
+          "internalType": "contract RouterProxy"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "instantiate",
+      "inputs": [
+        { "name": "owner", "type": "address", "internalType": "address" },
+        {
+          "name": "routerImplementation",
+          "type": "address",
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "proxy",
+          "type": "address",
+          "internalType": "contract RouterProxy"
+        },
+        { "name": "created", "type": "bool", "internalType": "bool" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "ProxyDeployed",
+      "inputs": [
+        {
+          "name": "proxy",
+          "type": "address",
+          "indexed": false,
+          "internalType": "contract RouterProxy"
+        },
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "implementation",
+          "type": "address",
+          "indexed": true,
+          "internalType": "contract AbstractRouter"
+        }
+      ],
+      "anonymous": false
+    }
+  ]
+}

--- a/src/assets/strats/v2.0.1-0/SimpleAaveLogic.json
+++ b/src/assets/strats/v2.0.1-0/SimpleAaveLogic.json
@@ -1,0 +1,264 @@
+{
+  "$schema": "../../../../contract.schema.json",
+  "released": false,
+  "contractName": "SimpleAaveLogic",
+  "version": "2.0.1-0",
+  "networkAddresses": {
+    "80001": {
+      "primaryAddress": "0x02FF1983c6400fAad57D47D52733c8c16B9a8236",
+      "allAddresses": [
+        {
+          "address": "0x02FF1983c6400fAad57D47D52733c8c16B9a8236",
+          "dependencies": [
+            {
+              "name": "Mangrove",
+              "address": "0x80cd6Ef14c23dD3957FD5629141a9d7028557c39"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "addressesProvider",
+          "type": "address",
+          "internalType": "contract IPoolAddressesProvider"
+        },
+        {
+          "name": "interestRateMode",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "ADDRESS_PROVIDER",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract IPoolAddressesProvider"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "IMPLEMENTATION",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "INTEREST_RATE_MODE",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ORACLE",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract IPriceOracleGetter"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "POOL",
+      "inputs": [],
+      "outputs": [
+        { "name": "", "type": "address", "internalType": "contract IPool" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "REFERRAL_CODE",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "uint16", "internalType": "uint16" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "_staticdelegatecall",
+      "inputs": [{ "name": "data", "type": "bytes", "internalType": "bytes" }],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "balanceLogic",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        { "name": "fundOwner", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [
+        { "name": "balance", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "borrowed",
+      "inputs": [
+        { "name": "underlying", "type": "address", "internalType": "address" },
+        { "name": "account", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [
+        { "name": "debt", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "checkAsset",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "debtToken",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        {
+          "name": "interestRateMode",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "debtTkn",
+          "type": "address",
+          "internalType": "contract ICreditDelegationToken"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getCaps",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [
+        { "name": "supplyCap", "type": "uint256", "internalType": "uint256" },
+        { "name": "borrowCap", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "maxGettableUnderlying",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        { "name": "tryBorrow", "type": "bool", "internalType": "bool" },
+        { "name": "onBehalf", "type": "address", "internalType": "address" }
+      ],
+      "outputs": [
+        {
+          "name": "maxRedeemableUnderlying",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "maxBorrowAfterRedeemInUnderlying",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "overlying",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "aToken",
+          "type": "address",
+          "internalType": "contract IERC20"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "pullLogic",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        { "name": "fundOwner", "type": "address", "internalType": "address" },
+        { "name": "amount", "type": "uint256", "internalType": "uint256" },
+        { "name": "strict", "type": "bool", "internalType": "bool" }
+      ],
+      "outputs": [
+        { "name": "pulled", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "pushLogic",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "contract IERC20"
+        },
+        { "name": "fundOwner", "type": "address", "internalType": "address" },
+        { "name": "amount", "type": "uint256", "internalType": "uint256" }
+      ],
+      "outputs": [
+        { "name": "pushed", "type": "uint256", "internalType": "uint256" }
+      ],
+      "stateMutability": "nonpayable"
+    }
+  ]
+}

--- a/src/strats.ts
+++ b/src/strats.ts
@@ -16,8 +16,15 @@ import RouterProxyFactory_v2_0_0_b1_0 from "./assets/strats/v2.0.0-b1.0/RouterPr
 import SimpleAaveLogic_v2_0_0_b1_0 from "./assets/strats/v2.0.0-b1.0/SimpleAaveLogic.json";
 import MangroveAmplifier_v2_0_0_b1_0 from "./assets/strats/v2.0.0-b1.0/MangroveAmplifier.json";
 // v2.0.1-0
+import AaveKandelSeeder_v2_0_1_0 from "./assets/strats/v2.0.1-0/AaveKandelSeeder.json";
+import AavePooledRouter_v2_0_1_0 from "./assets/strats/v2.0.1-0/AavePooledRouter.json";
 import KandelLib_v2_0_1_0 from "./assets/strats/v2.0.1-0/KandelLib.json";
 import KandelSeeder_v2_0_1_0 from "./assets/strats/v2.0.1-0/KandelSeeder.json";
+import MangroveAmplifier_v2_0_1_0 from "./assets/strats/v2.0.1-0/MangroveAmplifier.json";
+import MangroveOrderRouter_v2_0_1_0 from "./assets/strats/v2.0.1-0/MangroveOrder-Router.json";
+import MangroveOrder_v2_0_1_0 from "./assets/strats/v2.0.1-0/MangroveOrder.json";
+import RouterProxyFactory_v2_0_1_0 from "./assets/strats/v2.0.1-0/RouterProxyFactory.json";
+import SimpleAaveLogic_v2_0_1_0 from "./assets/strats/v2.0.1-0/SimpleAaveLogic.json";
 // v2.1.0-0
 import BlastMangroveAmplifier_v2_1_0_0 from "./assets/strats/v2.1.0-0/BlastMangroveAmplifier.json";
 import BlastMangroveOrderRouter_v2_1_0_0 from "./assets/strats/v2.1.0-0/BlastMangroveOrder-Router.json";
@@ -43,6 +50,7 @@ import {
 
 /** This is a sorted array (newest to oldest), exported for tests */
 export const _aaveKandelSeederDeployments: VersionDeployments[] = [
+  AaveKandelSeeder_v2_0_1_0,
   AaveKandelSeeder_v2_0_0_b1_0,
   AaveKandelSeeder_v1_0_0,
 ];
@@ -72,6 +80,7 @@ export const getLatestAaveKandelSeederPerNetwork = (
 
 /** This is a sorted array (newest to oldest), exported for tests */
 export const _aavePooledRouterDeployments: VersionDeployments[] = [
+  AavePooledRouter_v2_0_1_0,
   AavePooledRouter_v2_0_0_b1_0,
   AavePooledRouter_v1_0_0,
 ];
@@ -162,6 +171,7 @@ export const getLatestKandelSeederPerNetwork = (
 /** This is a sorted array (newest to oldest), exported for tests */
 export const _mangroveOrderRouterDeployments: VersionDeployments[] = [
   BlastMangroveOrderRouter_v2_1_0_0,
+  MangroveOrderRouter_v2_0_1_0,
   MangroveOrderRouter_v2_0_0_b1_0,
   MangroveOrderRouter_v1_0_0,
 ];
@@ -195,6 +205,7 @@ export const getLatestMangroveOrderRouterPerNetwork = (
 /** This is a sorted array (newest to oldest), exported for tests */
 export const _mangroveOrderDeployments: VersionDeployments[] = [
   BlastMangroveOrder_v2_1_0_0,
+  MangroveOrder_v2_0_1_0,
   MangroveOrder_v2_0_0_b1_0,
   MangroveOrder_v1_0_0,
 ];
@@ -225,6 +236,7 @@ export const getLatestMangroveOrderPerNetwork = (
 /** This is a sorted array (newest to oldest), exported for tests */
 export const _routerProxyFactoryDeployments: VersionDeployments[] = [
   BlastRouterProxyFactory_v2_1_0_0,
+  RouterProxyFactory_v2_0_1_0,
   RouterProxyFactory_v2_0_0_b1_0,
 ];
 
@@ -253,6 +265,7 @@ export const getLatestRouterProxyFactoryPerNetwork = (
 
 /** This is a sorted array (newest to oldest), exported for tests */
 export const _simpleAaveLogicDeployments: VersionDeployments[] = [
+  SimpleAaveLogic_v2_0_1_0,
   SimpleAaveLogic_v2_0_0_b1_0,
 ];
 
@@ -282,6 +295,7 @@ export const getLatestSimpleAaveLogicPerNetwork = (
 /** This is a sorted array (newest to oldest), exported for tests */
 export const _mangroveAmplifierDeployments: VersionDeployments[] = [
   BlastMangroveAmplifier_v2_1_0_0,
+  MangroveAmplifier_v2_0_1_0,
   MangroveAmplifier_v2_0_0_b1_0,
 ];
 

--- a/test/unit/strats.unit.test.ts
+++ b/test/unit/strats.unit.test.ts
@@ -21,8 +21,15 @@ import RouterProxyFactory_v2_0_0_b1_0 from "../../src/assets/strats/v2.0.0-b1.0/
 import SimpleAaveLogic_v2_0_0_b1_0 from "../../src/assets/strats/v2.0.0-b1.0/SimpleAaveLogic.json";
 import MangroveAmplifier_v2_0_0_b1_0 from "../../src/assets/strats/v2.0.0-b1.0/MangroveAmplifier.json";
 // v2.0.1-0
+import AaveKandelSeeder_v2_0_1_0 from "../../src/assets/strats/v2.0.1-0/AaveKandelSeeder.json";
+import AavePooledRouter_v2_0_1_0 from "../../src/assets/strats/v2.0.1-0/AavePooledRouter.json";
 import KandelLib_v2_0_1_0 from "../../src/assets/strats/v2.0.1-0/KandelLib.json";
 import KandelSeeder_v2_0_1_0 from "../../src/assets/strats/v2.0.1-0/KandelSeeder.json";
+import MangroveAmplifier_v2_0_1_0 from "../../src/assets/strats/v2.0.1-0/MangroveAmplifier.json";
+import MangroveOrderRouter_v2_0_1_0 from "../../src/assets/strats/v2.0.1-0/MangroveOrder-Router.json";
+import MangroveOrder_v2_0_1_0 from "../../src/assets/strats/v2.0.1-0/MangroveOrder.json";
+import RouterProxyFactory_v2_0_1_0 from "../../src/assets/strats/v2.0.1-0/RouterProxyFactory.json";
+import SimpleAaveLogic_v2_0_1_0 from "../../src/assets/strats/v2.0.1-0/SimpleAaveLogic.json";
 // v2.1.0-0
 import BlastMangroveAmplifier_v2_1_0_0 from "../../src/assets/strats/v2.1.0-0/BlastMangroveAmplifier.json";
 import BlastMangroveOrderRouter_v2_1_0_0 from "../../src/assets/strats/v2.1.0-0/BlastMangroveOrder-Router.json";
@@ -69,11 +76,13 @@ describe("strats.ts", () => {
         const result = getAaveKandelSeederVersionDeployments({
           released: undefined,
         });
-        assert.equal(result, AaveKandelSeeder_v2_0_0_b1_0);
+        assert.equal(result, AaveKandelSeeder_v2_0_1_0);
         // NB: Add older old versions here
-        [AaveKandelSeeder_v1_0_0].forEach((version) => {
-          assert.notEqual(result, version);
-        });
+        [AaveKandelSeeder_v2_0_0_b1_0, AaveKandelSeeder_v1_0_0].forEach(
+          (version) => {
+            assert.notEqual(result, version);
+          },
+        );
       });
     });
 
@@ -84,7 +93,11 @@ describe("strats.ts", () => {
             released: undefined,
           }),
         ).to.deep.equal({
-          "80001": [AaveKandelSeeder_v2_0_0_b1_0, AaveKandelSeeder_v1_0_0],
+          "80001": [
+            AaveKandelSeeder_v2_0_1_0,
+            AaveKandelSeeder_v2_0_0_b1_0,
+            AaveKandelSeeder_v1_0_0,
+          ],
         });
       });
     });
@@ -95,7 +108,7 @@ describe("strats.ts", () => {
           getLatestAaveKandelSeederPerNetwork({ released: undefined }),
         ).to.deep.equal({
           "80001": firstVersionDeploymentsToVersionNetworkDeployment(
-            AaveKandelSeeder_v2_0_0_b1_0,
+            AaveKandelSeeder_v2_0_1_0,
             "80001",
           ),
         });
@@ -109,11 +122,13 @@ describe("strats.ts", () => {
         const result = getAavePooledRouterVersionDeployments({
           released: undefined,
         });
-        assert.equal(result, AavePooledRouter_v2_0_0_b1_0);
+        assert.equal(result, AavePooledRouter_v2_0_1_0);
         // NB: Add older old versions here
-        [AavePooledRouter_v1_0_0].forEach((version) => {
-          assert.notEqual(result, version);
-        });
+        [AavePooledRouter_v2_0_0_b1_0, AavePooledRouter_v1_0_0].forEach(
+          (version) => {
+            assert.notEqual(result, version);
+          },
+        );
       });
     });
 
@@ -124,7 +139,11 @@ describe("strats.ts", () => {
             released: undefined,
           }),
         ).to.deep.equal({
-          "80001": [AavePooledRouter_v2_0_0_b1_0, AavePooledRouter_v1_0_0],
+          "80001": [
+            AavePooledRouter_v2_0_1_0,
+            AavePooledRouter_v2_0_0_b1_0,
+            AavePooledRouter_v1_0_0,
+          ],
         });
       });
     });
@@ -135,7 +154,7 @@ describe("strats.ts", () => {
           getLatestAavePooledRouterPerNetwork({ released: undefined }),
         ).to.deep.equal({
           "80001": firstVersionDeploymentsToVersionNetworkDeployment(
-            AavePooledRouter_v2_0_0_b1_0,
+            AavePooledRouter_v2_0_1_0,
             "80001",
           ),
         });
@@ -160,7 +179,11 @@ describe("strats.ts", () => {
         expect(
           getAllKandelLibVersionDeploymentsPerNetwork({ released: undefined }),
         ).to.deep.equal({
-          "80001": [KandelLib_v2_0_0_b1_0, KandelLib_v1_0_0],
+          "80001": [
+            KandelLib_v2_0_1_0,
+            KandelLib_v2_0_0_b1_0,
+            KandelLib_v1_0_0,
+          ],
           "168587773": [KandelLib_v2_0_1_0],
         });
       });
@@ -172,7 +195,7 @@ describe("strats.ts", () => {
           getLatestKandelLibPerNetwork({ released: undefined }),
         ).to.deep.equal({
           "80001": firstVersionDeploymentsToVersionNetworkDeployment(
-            KandelLib_v2_0_0_b1_0,
+            KandelLib_v2_0_1_0,
             "80001",
           ),
           "168587773": firstVersionDeploymentsToVersionNetworkDeployment(
@@ -205,7 +228,11 @@ describe("strats.ts", () => {
             released: undefined,
           }),
         ).to.deep.equal({
-          "80001": [KandelSeeder_v2_0_0_b1_0, KandelSeeder_v1_0_0],
+          "80001": [
+            KandelSeeder_v2_0_1_0,
+            KandelSeeder_v2_0_0_b1_0,
+            KandelSeeder_v1_0_0,
+          ],
           "168587773": [KandelSeeder_v2_0_1_0],
         });
       });
@@ -217,7 +244,7 @@ describe("strats.ts", () => {
           getLatestKandelSeederPerNetwork({ released: undefined }),
         ).to.deep.equal({
           "80001": firstVersionDeploymentsToVersionNetworkDeployment(
-            KandelSeeder_v2_0_0_b1_0,
+            KandelSeeder_v2_0_1_0,
             "80001",
           ),
           "168587773": firstVersionDeploymentsToVersionNetworkDeployment(
@@ -237,11 +264,13 @@ describe("strats.ts", () => {
         });
         assert.equal(result, BlastMangroveOrderRouter_v2_1_0_0);
         // NB: Add older old versions here
-        [MangroveOrderRouter_v2_0_0_b1_0, MangroveOrderRouter_v1_0_0].forEach(
-          (version) => {
-            assert.notEqual(result, version);
-          },
-        );
+        [
+          MangroveOrderRouter_v2_0_1_0,
+          MangroveOrderRouter_v2_0_0_b1_0,
+          MangroveOrderRouter_v1_0_0,
+        ].forEach((version) => {
+          assert.notEqual(result, version);
+        });
       });
     });
 
@@ -253,6 +282,7 @@ describe("strats.ts", () => {
           }),
         ).to.deep.equal({
           "80001": [
+            MangroveOrderRouter_v2_0_1_0,
             MangroveOrderRouter_v2_0_0_b1_0,
             MangroveOrderRouter_v1_0_0,
           ],
@@ -267,7 +297,7 @@ describe("strats.ts", () => {
           getLatestMangroveOrderRouterPerNetwork({ released: undefined }),
         ).to.deep.equal({
           "80001": firstVersionDeploymentsToVersionNetworkDeployment(
-            MangroveOrderRouter_v2_0_0_b1_0,
+            MangroveOrderRouter_v2_0_1_0,
             "80001",
           ),
           "168587773": firstVersionDeploymentsToVersionNetworkDeployment(
@@ -287,7 +317,11 @@ describe("strats.ts", () => {
         });
         assert.equal(result, BlastMangroveOrder_v2_1_0_0);
         // NB: Add older old versions here
-        [MangroveOrder_v2_0_0_b1_0, MangroveOrder_v1_0_0].forEach((version) => {
+        [
+          MangroveOrder_v2_0_1_0,
+          MangroveOrder_v2_0_0_b1_0,
+          MangroveOrder_v1_0_0,
+        ].forEach((version) => {
           assert.notEqual(result, version);
         });
       });
@@ -300,7 +334,11 @@ describe("strats.ts", () => {
             released: undefined,
           }),
         ).to.deep.equal({
-          "80001": [MangroveOrder_v2_0_0_b1_0, MangroveOrder_v1_0_0],
+          "80001": [
+            MangroveOrder_v2_0_1_0,
+            MangroveOrder_v2_0_0_b1_0,
+            MangroveOrder_v1_0_0,
+          ],
           "168587773": [BlastMangroveOrder_v2_1_0_0],
         });
       });
@@ -312,7 +350,7 @@ describe("strats.ts", () => {
           getLatestMangroveOrderPerNetwork({ released: undefined }),
         ).to.deep.equal({
           "80001": firstVersionDeploymentsToVersionNetworkDeployment(
-            MangroveOrder_v2_0_0_b1_0,
+            MangroveOrder_v2_0_1_0,
             "80001",
           ),
           "168587773": firstVersionDeploymentsToVersionNetworkDeployment(
@@ -332,9 +370,11 @@ describe("strats.ts", () => {
         });
         assert.equal(result, BlastRouterProxyFactory_v2_1_0_0);
         // NB: Add older old versions here
-        [RouterProxyFactory_v2_0_0_b1_0].forEach((version) => {
-          assert.notEqual(result, version);
-        });
+        [RouterProxyFactory_v2_0_1_0, RouterProxyFactory_v2_0_0_b1_0].forEach(
+          (version) => {
+            assert.notEqual(result, version);
+          },
+        );
       });
     });
 
@@ -345,7 +385,10 @@ describe("strats.ts", () => {
             released: undefined,
           }),
         ).to.deep.equal({
-          "80001": [RouterProxyFactory_v2_0_0_b1_0],
+          "80001": [
+            RouterProxyFactory_v2_0_1_0,
+            RouterProxyFactory_v2_0_0_b1_0,
+          ],
           "168587773": [BlastRouterProxyFactory_v2_1_0_0],
         });
       });
@@ -357,7 +400,7 @@ describe("strats.ts", () => {
           getLatestRouterProxyFactoryPerNetwork({ released: undefined }),
         ).to.deep.equal({
           "80001": firstVersionDeploymentsToVersionNetworkDeployment(
-            RouterProxyFactory_v2_0_0_b1_0,
+            RouterProxyFactory_v2_0_1_0,
             "80001",
           ),
           "168587773": firstVersionDeploymentsToVersionNetworkDeployment(
@@ -375,9 +418,9 @@ describe("strats.ts", () => {
         const result = getSimpleAaveLogicVersionDeployments({
           released: undefined,
         });
-        assert.equal(result, SimpleAaveLogic_v2_0_0_b1_0);
+        assert.equal(result, SimpleAaveLogic_v2_0_1_0);
         // NB: Add older old versions here
-        [].forEach((version) => {
+        [SimpleAaveLogic_v2_0_0_b1_0].forEach((version) => {
           assert.notEqual(result, version);
         });
       });
@@ -390,7 +433,7 @@ describe("strats.ts", () => {
             released: undefined,
           }),
         ).to.deep.equal({
-          "80001": [SimpleAaveLogic_v2_0_0_b1_0],
+          "80001": [SimpleAaveLogic_v2_0_1_0, SimpleAaveLogic_v2_0_0_b1_0],
         });
       });
     });
@@ -401,7 +444,7 @@ describe("strats.ts", () => {
           getLatestSimpleAaveLogicPerNetwork({ released: undefined }),
         ).to.deep.equal({
           "80001": firstVersionDeploymentsToVersionNetworkDeployment(
-            SimpleAaveLogic_v2_0_0_b1_0,
+            SimpleAaveLogic_v2_0_1_0,
             "80001",
           ),
         });
@@ -417,9 +460,11 @@ describe("strats.ts", () => {
         });
         assert.equal(result, BlastMangroveAmplifier_v2_1_0_0);
         // NB: Add older old versions here
-        [MangroveAmplifier_v2_0_0_b1_0].forEach((version) => {
-          assert.notEqual(result, version);
-        });
+        [MangroveAmplifier_v2_0_1_0, MangroveAmplifier_v2_0_0_b1_0].forEach(
+          (version) => {
+            assert.notEqual(result, version);
+          },
+        );
       });
     });
 
@@ -430,7 +475,7 @@ describe("strats.ts", () => {
             released: undefined,
           }),
         ).to.deep.equal({
-          "80001": [MangroveAmplifier_v2_0_0_b1_0],
+          "80001": [MangroveAmplifier_v2_0_1_0, MangroveAmplifier_v2_0_0_b1_0],
           "168587773": [BlastMangroveAmplifier_v2_1_0_0],
         });
       });
@@ -442,7 +487,7 @@ describe("strats.ts", () => {
           getLatestMangroveAmplifierPerNetwork({ released: undefined }),
         ).to.deep.equal({
           "80001": firstVersionDeploymentsToVersionNetworkDeployment(
-            MangroveAmplifier_v2_0_0_b1_0,
+            MangroveAmplifier_v2_0_1_0,
             "80001",
           ),
           "168587773": firstVersionDeploymentsToVersionNetworkDeployment(
@@ -465,40 +510,40 @@ describe("strats.ts", () => {
             "80001",
           ),
           aaveKandelSeeder: firstVersionDeploymentsToVersionNetworkDeployment(
-            AaveKandelSeeder_v2_0_0_b1_0,
+            AaveKandelSeeder_v2_0_1_0,
             "80001",
           ),
           aavePooledRouter: firstVersionDeploymentsToVersionNetworkDeployment(
-            AavePooledRouter_v2_0_0_b1_0,
+            AavePooledRouter_v2_0_1_0,
             "80001",
           ),
           kandelLib: firstVersionDeploymentsToVersionNetworkDeployment(
-            KandelLib_v2_0_0_b1_0,
+            KandelLib_v2_0_1_0,
             "80001",
           ),
           kandelSeeder: firstVersionDeploymentsToVersionNetworkDeployment(
-            KandelSeeder_v2_0_0_b1_0,
+            KandelSeeder_v2_0_1_0,
             "80001",
           ),
           mangroveOrderRouter:
             firstVersionDeploymentsToVersionNetworkDeployment(
-              MangroveOrderRouter_v2_0_0_b1_0,
+              MangroveOrderRouter_v2_0_1_0,
               "80001",
             ),
           mangroveOrder: firstVersionDeploymentsToVersionNetworkDeployment(
-            MangroveOrder_v2_0_0_b1_0,
+            MangroveOrder_v2_0_1_0,
             "80001",
           ),
           routerProxyFactory: firstVersionDeploymentsToVersionNetworkDeployment(
-            RouterProxyFactory_v2_0_0_b1_0,
+            RouterProxyFactory_v2_0_1_0,
             "80001",
           ),
           simpleAaveLogic: firstVersionDeploymentsToVersionNetworkDeployment(
-            SimpleAaveLogic_v2_0_0_b1_0,
+            SimpleAaveLogic_v2_0_1_0,
             "80001",
           ),
           mangroveAmplifier: firstVersionDeploymentsToVersionNetworkDeployment(
-            MangroveAmplifier_v2_0_0_b1_0,
+            MangroveAmplifier_v2_0_1_0,
             "80001",
           ),
         },


### PR DESCRIPTION
Add deployments of strat contracts v2.0.1-0 to Mumbai.

Except for `MangroveAmplifier` these are identical to the v2.0.0-b1.0 deployments, as no code was changed in-between; We duplicate them, so we can later simplify and just delete the v2.0.0-b1.0 deployments.